### PR TITLE
Update main.yml to run nightly tests on self-hosted runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   # Run every day at 3:00 AM EDT (i.e., 7 am UTC)
   schedule:
     - cron: "0 7 * * *"
+  workflow_dispatch:
 
 env:
   benchmark_tar_dir: "/home/github/checkedc-benchmarks"


### PR DESCRIPTION
Updates our actions to run on a self-hosted runner (gamera).  For these to work we will need to enable self hosted runners for this repository and provide gamera with a key to allow it to access this repository . 

Addresses correctcomputation/checkedc-clang#300.