### PR TITLE
Add parameter to configure branch of 3C tested on manual workflow run

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
   # Clone and build 3C
   build_3c:
-    name: Build 3C
+    name: "Build 3C (${{ github.event.inputs.branch || env.branch_for_scheduled_run }})"
     needs: clean
     runs-on: self-hosted
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,10 +35,12 @@ jobs:
 
   # Clone and build 3C
   build_3c:
-    name: "Build 3C (${{ github.event.inputs.branch || env.branch_for_scheduled_run }})"
+    name: Build 3C
     needs: clean
     runs-on: self-hosted
     steps:
+      - name: Branch or commit ID
+        run: echo "${{ github.event.inputs.branch || env.branch_for_scheduled_run }}"
       - name: Checkout our repository
         run: |
           git init ${{github.workspace}}/depsfolder/checkedc-clang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,11 +5,17 @@ on:
   schedule:
     - cron: "0 7 * * *"
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch of correctcomputation/checkedc-clang to run workflow on"
+        required: true
+        default: "main"
 
 env:
   benchmark_tar_dir: "/home/github/checkedc-benchmarks"
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
+  branch_for_scheduled_run: "main"
 
 jobs:
 
@@ -36,6 +42,9 @@ jobs:
       - name: Checkout our repository
         run: |
           git clone --depth 1 https://github.com/correctcomputation/checkedc-clang ${{github.workspace}}/depsfolder/checkedc-clang
+          cd ${{github.workspace}}/depsfolder/checkedc-clang
+          git fetch --depth 1 origin "${{ github.event.inputs.branch || env.branch_for_scheduled_run }}"
+          git checkout FETCH_HEAD
           git clone --depth 1 https://github.com/microsoft/checkedc ${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc
 
       - name: Build 3c

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch of correctcomputation/checkedc-clang to run workflow on"
+        description: "Branch or commit ID of correctcomputation/checkedc-clang to run workflow on"
         required: true
         default: "main"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,9 @@ jobs:
     steps:
       - name: Checkout our repository
         run: |
-          git clone --depth 1 https://github.com/correctcomputation/checkedc-clang ${{github.workspace}}/depsfolder/checkedc-clang
+          git init ${{github.workspace}}/depsfolder/checkedc-clang
           cd ${{github.workspace}}/depsfolder/checkedc-clang
+          git remote add origin https://github.com/correctcomputation/checkedc-clang
           git fetch --depth 1 origin "${{ github.event.inputs.branch || env.branch_for_scheduled_run }}"
           git checkout FETCH_HEAD
           git clone --depth 1 https://github.com/microsoft/checkedc ${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc


### PR DESCRIPTION
With this change we will be able to specify the commit or branch of 3C ([correctcomputation/checkedc-clang](https://github.com/correctcomputation/checkedc-clang)) to run the actions on when manually triggering the actions. 