### PR TITLE
Reduce the targets built by the workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           cd ${{env.builddir}}
           cmake -G Ninja -DLLVM_TARGETS_TO_BUILD=X86 -DLLVM_ENABLE_RTTI=ON -DCMAKE_BUILD_TYPE="Debug" -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra" ${{github.workspace}}/depsfolder/checkedc-clang/llvm
-          ninja 3c clang llvm-config FileCheck not count c-index-test clang-diff clang-format opt clang-check
+          ninja 3c clang
           chmod -R 777 ${{github.workspace}}/depsfolder
           chmod -R 777 ${{env.builddir}}
 
@@ -67,7 +67,7 @@ jobs:
       - name: 3C tests
         run: |
           cd ${{env.builddir}}
-          ninja check-clang-3c
+          ninja check-3c
 
   # Convert out benchmark programs
   test_vsftpd:


### PR DESCRIPTION
- The regression tests should use the new `check-3c` target instead of
  `check-clang-3c`.

- The "Build 3C" step only needs to build `3c`; the inclusion of the
  other targets there was from when "Test 3C" just ran `lit` instead of
  `ninja check-clang-3c`. But build `clang` too in anticipation of the
  benchmarks being enhanced to use it.

[Tested](https://github.com/correctcomputation/actions/actions/runs/618779686).  John: I see [you have another change in progress](https://github.com/correctcomputation/actions/compare/format_and_cleanup), but this doesn't modify any of the same lines, so it should merge OK.