### PR TITLE
Run convert_project in a distinct working directory.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,11 +124,12 @@ jobs:
 
       - name: Convert Vsftpd
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
 
       - name: Build converted Vsftpd
         run: |
@@ -152,12 +153,13 @@ jobs:
 
       - name: Convert Vsftpd
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
 
       - name: Build converted Vsftpd (ignore failure)
         run: |
@@ -183,11 +185,12 @@ jobs:
 
       - name: Convert anagram
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
 
       - name: Build converted anagram
         run: |
@@ -198,11 +201,12 @@ jobs:
 
       - name: Convert bc
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
 
       - name: Build converted bc
         run: |
@@ -213,11 +217,12 @@ jobs:
 
       - name: Convert ft
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
 
       - name: Build converted ft
         run: |
@@ -228,11 +233,12 @@ jobs:
 
       - name: Convert ks
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
 
       - name: Build converted ks
         run: |
@@ -243,11 +249,12 @@ jobs:
 
       - name: Convert yacr2
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
 
       - name: Build converted yacr2
         run: |
@@ -273,12 +280,13 @@ jobs:
 
       - name: Convert anagram
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
 
       - name: Build converted anagram (ignore failure)
         run: |
@@ -289,12 +297,13 @@ jobs:
 
       - name: Convert bc
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
 
       - name: Build converted bc (ignore failure)
         run: |
@@ -305,12 +314,13 @@ jobs:
 
       - name: Convert ft
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
 
       - name: Build converted ft (ignore failure)
         run: |
@@ -321,12 +331,13 @@ jobs:
 
       - name: Convert ks
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
 
       - name: Build converted ks (ignore failure)
         run: |
@@ -337,12 +348,13 @@ jobs:
 
       - name: Convert yacr2
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
 
       - name: Build converted yacr2 (ignore failure)
         run: |
@@ -368,13 +380,14 @@ jobs:
 
       - name: Convert LibArchive
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path . \
-            --build_dir build
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3 \
+            --build_dir ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3/build
 
       - name: Build converted LibArchive
         run: |
@@ -401,14 +414,15 @@ jobs:
 
       - name: Convert LibArchive
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path . \
-            --build_dir build
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3 \
+            --build_dir ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3/build
 
       - name: Build converted LibArchive (ignore failure)
         run: |
@@ -438,11 +452,12 @@ jobs:
 
       - name: Convert Lua
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
 
       - name: Build converted Lua
         run: |
@@ -471,12 +486,13 @@ jobs:
 
       - name: Convert Lua
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1.work
           ${{env.port_tools}}/convert_project.py \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
 
       - name: Build converted Lua (ignore failure)
         run: |
@@ -507,14 +523,15 @@ jobs:
 
       - name: Convert LibTiff
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0
 
       - name: Build converted LibTiff
         run: |
@@ -545,7 +562,8 @@ jobs:
 
       - name: Convert LibTiff
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/tiff-4.1.0
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/tiff-4.1.0.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/tiff-4.1.0.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
@@ -553,7 +571,7 @@ jobs:
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path .
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/tiff-4.1.0
 
       - name: Build converted LibTiff (ignore failure)
         run: |
@@ -580,13 +598,14 @@ jobs:
 
       - name: Convert ZLib
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11
+          mkdir ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11.work
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
-            --project_path . \
-            --build_dir build
+            --project_path ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11 \
+            --build_dir ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11/build
 
       - name: Build converted ZLib
         run: |
@@ -614,14 +633,15 @@ jobs:
 
       - name: Convert ZLib
         run: |
-          cd ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11
+          mkdir ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11.work
+          cd ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11.work
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
-            --project_path . \
-            --build_dir build
+            --project_path ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11 \
+            --build_dir ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11/build
 
       - name: Build converted ZLib (ignore failure)
         run: |

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -338,8 +338,8 @@ with open('.github/workflows/main.yml', 'w') as out:
                     '--includeDir ${{env.include_dir}} \\\n' +
                     '--prog_name ${{env.builddir}}/bin/3c \\\n' +
                     at_flag +
-                    '--project_path .' +
-                    (f' \\\n--build_dir {component.build_dir}'
+                    f'--project_path {component_dir}' +
+                    (f' \\\n--build_dir {component_dir}/{component.build_dir}'
                      if component.build_dir is not None else '') +
                     '\n',
                     2 * ' ')
@@ -347,8 +347,17 @@ with open('.github/workflows/main.yml', 'w') as out:
                 steps.append(
                     Step(
                         'Convert ' + component_friendly_name,
+                        # Choose a working directory different from all the
+                        # other important directories involved (the source
+                        # directory, build directory, etc.) to detect if
+                        # anything called by convert_project inappropriately
+                        # assumes that the working directory matches one of
+                        # those other directories. If anything called by
+                        # convert_project writes diagnostic files to its working
+                        # directory, this also helps to keep them separate.
                         textwrap.dedent(f'''\
-                        cd {component_dir}
+                        mkdir {component_dir}.work
+                        cd {component_dir}.work
                         ${{{{env.port_tools}}}}/convert_project.py \\
                         ''') + convert_flags))
 


### PR DESCRIPTION
This should detect if anything run by convert_project inappropriately assumes that the working directory is the same as one of the other important directories involved (the source directory, build directory, etc.).

Example: With correctcomputation/checkedc-clang#488 modified to use the original `getCanonicalFilePath` (which may assert when the working directory differs from the `directory` field in the compilation database: [details](https://github.com/correctcomputation/checkedc-clang/pull/488#issuecomment-799859671)), [we now see the failure in vsftpd](https://github.com/correctcomputation/actions/runs/2123932762?check_suite_focus=true).  Previously [it was masked](https://github.com/correctcomputation/actions/runs/2117137048?check_suite_focus=true) because the workflow set the working directory to the project base directory, which equals the compilation database `directory` field in the case of vsftpd.