### PR TITLE
Test scripts tweaks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -382,7 +382,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k
+          make -k archive
 
   test_libarchive_alltypes:
     name: Test LibArchive (-alltypes)
@@ -416,7 +416,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k || true
+          make -k archive || true
 
   test_lua_no_alltypes:
     name: Test Lua (no -alltypes)
@@ -449,6 +449,10 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
+          clang-rename-10 -pl -i \
+            --qualified-name=luac_main \
+            --new-name=main \
+            luac.c )
           make CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
@@ -483,6 +487,10 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
+          clang-rename-10 -pl -i \
+            --qualified-name=luac_main \
+            --new-name=main \
+            luac.c )
           make CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:
@@ -594,7 +602,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k zlib zlibstatic
+          make -k zlib
 
   test_zlib_alltypes:
     name: Test ZLib (-alltypes)
@@ -629,4 +637,4 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k zlib zlibstatic || true
+          make -k zlib || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -449,7 +449,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          sed -i "s/luac_main/main/" src/luac.c \
+          sed -i "s/luac_main/main/" src/luac.c
           make CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
@@ -484,7 +484,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          sed -i "s/luac_main/main/" src/luac.c \
+          sed -i "s/luac_main/main/" src/luac.c
           make CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -594,7 +594,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k
+          make -k zlib zlibstatic
 
   test_zlib_alltypes:
     name: Test ZLib (-alltypes)
@@ -629,4 +629,4 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k || true
+          make -k zlib zlibstatic || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -449,11 +449,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          ( cd src ; \
-            clang-rename-10 -pl -i \
-              --qualified-name=luac_main \
-              --new-name=main \
-              luac.c )
+          sed -i "s/luac_main/main/" src/luac.c \
           make CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
@@ -488,11 +484,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          ( cd src ; \
-            clang-rename-10 -pl -i \
-              --qualified-name=luac_main \
-              --new-name=main \
-              luac.c )
+          sed -i "s/luac_main/main/" src/luac.c \
           make CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,7 +364,7 @@ jobs:
           cd libarchive-3.4.3
           cd build
           cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
-          bear make
+          bear make archive
 
       - name: Convert LibArchive
         run: |
@@ -397,7 +397,7 @@ jobs:
           cd libarchive-3.4.3
           cd build
           cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
-          bear make
+          bear make archive
 
       - name: Convert LibArchive
         run: |
@@ -578,7 +578,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" ..
-          bear make
+          bear make zlib
 
       - name: Convert ZLib
         run: |
@@ -612,7 +612,7 @@ jobs:
           mkdir build
           cd build
           cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" ..
-          bear make
+          bear make zlib
 
       - name: Convert ZLib
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -449,10 +449,11 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          clang-rename-10 -pl -i \
-            --qualified-name=luac_main \
-            --new-name=main \
-            luac.c )
+          ( cd src ; \
+            clang-rename-10 -pl -i \
+              --qualified-name=luac_main \
+              --new-name=main \
+              luac.c )
           make CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
@@ -487,10 +488,11 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
-          clang-rename-10 -pl -i \
-            --qualified-name=luac_main \
-            --new-name=main \
-            luac.c )
+          ( cd src ; \
+            clang-rename-10 -pl -i \
+              --qualified-name=luac_main \
+              --new-name=main \
+              luac.c )
           make CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -114,10 +114,11 @@ benchmarks = [
             luac.c )
         '''),
         build_converted_cmd=textwrap.dedent(f'''\
-        clang-rename-10 -pl -i \\
-          --qualified-name=luac_main \\
-          --new-name=main \\
-          luac.c )
+        ( cd src ; \\
+          clang-rename-10 -pl -i \\
+            --qualified-name=luac_main \\
+            --new-name=main \\
+            luac.c )
         {make_checkedc} -k linux
         ''')),
 

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -93,7 +93,7 @@ benchmarks = [
         {cmake_checkedc} -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
         bear make
         '''),
-        build_converted_cmd='make -k',
+        build_converted_cmd='make -k archive',
         convert_extra=textwrap.dedent('''\
         --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \\
         '''),
@@ -113,7 +113,13 @@ benchmarks = [
             --new-name=luac_main \\
             luac.c )
         '''),
-        build_converted_cmd=f'{make_checkedc} -k linux'),
+        build_converted_cmd=textwrap.dedent(f'''\
+        clang-rename-10 -pl -i \\
+          --qualified-name=luac_main \\
+          --new-name=main \\
+          luac.c )
+        {make_checkedc} -k linux
+        ''')),
 
     # LibTiff
     BenchmarkInfo(
@@ -150,7 +156,7 @@ benchmarks = [
         {cmake_checkedc} -DCMAKE_C_FLAGS="-w" ..
         bear make
         '''),
-        build_converted_cmd='make -k zlib zlibstatic',
+        build_converted_cmd='make -k zlib',
         convert_extra="--skip '/.*/test/.*' \\",
         components=[BenchmarkComponent(build_dir='build')]),
 ]

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -91,7 +91,7 @@ benchmarks = [
         build_cmds=textwrap.dedent(f'''\
         cd build
         {cmake_checkedc} -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
-        bear make
+        bear make archive
         '''),
         build_converted_cmd='make -k archive',
         convert_extra=textwrap.dedent('''\
@@ -155,7 +155,7 @@ benchmarks = [
         mkdir build
         cd build
         {cmake_checkedc} -DCMAKE_C_FLAGS="-w" ..
-        bear make
+        bear make zlib
         '''),
         build_converted_cmd='make -k zlib',
         convert_extra="--skip '/.*/test/.*' \\",

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -113,12 +113,12 @@ benchmarks = [
             --new-name=luac_main \\
             luac.c )
         '''),
+        # Undo the rename using sed because the system install of clang-rename
+        # can't handle checked pointers. This works since "luac_main" only
+        # appears in the locations where it was added as a result of the
+        # original rename.
         build_converted_cmd=textwrap.dedent(f'''\
-        ( cd src ; \\
-          clang-rename-10 -pl -i \\
-            --qualified-name=luac_main \\
-            --new-name=main \\
-            luac.c )
+        sed -i "s/luac_main/main/" src/luac.c \\
         {make_checkedc} -k linux
         ''')),
 

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -118,7 +118,7 @@ benchmarks = [
         # appears in the locations where it was added as a result of the
         # original rename.
         build_converted_cmd=textwrap.dedent(f'''\
-        sed -i "s/luac_main/main/" src/luac.c \\
+        sed -i "s/luac_main/main/" src/luac.c
         {make_checkedc} -k linux
         ''')),
 

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -150,7 +150,7 @@ benchmarks = [
         {cmake_checkedc} -DCMAKE_C_FLAGS="-w" ..
         bear make
         '''),
-        build_converted_cmd='make -k',
+        build_converted_cmd='make -k zlib zlibstatic',
         convert_extra="--skip '/.*/test/.*' \\",
         components=[BenchmarkComponent(build_dir='build')]),
 ]


### PR DESCRIPTION
* The test directory for zlib is not converted, so it isn't expected to compile with the converted library code.
* Similar fix for libarchive
* Undo renames before compiling lua so that the executable links