### PR TITLE
Add Icecast as a benchmark.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -630,3 +630,62 @@ jobs:
           rm -r out.checked
           cd build
           make -k || true
+
+  test_icecast_no_alltypes:
+    name: Test Icecast (no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Icecast
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
+          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
+          cd icecast-2.4.4
+          CC="${{env.builddir}}/bin/clang" ./configure
+          bear make
+
+      - name: Convert Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
+          ${{env.port_tools}}/convert_project.py \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -k
+
+  test_icecast_alltypes:
+    name: Test Icecast (-alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Icecast
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/alltypes
+          cd ${{env.benchmark_conv_dir}}/alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
+          cd icecast-2.4.4
+          CC="${{env.builddir}}/bin/clang" ./configure
+          bear make
+
+      - name: Convert Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
+          ${{env.port_tools}}/convert_project.py \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted Icecast (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -k || true

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -153,6 +153,18 @@ benchmarks = [
         build_converted_cmd='make -k',
         convert_extra="--skip '/.*/test/.*' \\",
         components=[BenchmarkComponent(build_dir='build')]),
+
+    # Icecast
+    BenchmarkInfo(
+        #
+        name='icecast',
+        friendly_name='Icecast',
+        dir_name='icecast-2.4.4',
+        build_cmds=textwrap.dedent('''\
+        CC="${{env.builddir}}/bin/clang" ./configure
+        bear make
+        '''),
+        build_converted_cmd='make -k'),
 ]
 
 HEADER = '''\


### PR DESCRIPTION
This was pretty straightforward following the instructions in https://github.com/correctcomputation/checkedc-clang/issues/315#issue-733237140.  It looks like the benchmark is working as intended, though (unsurprisingly) it is failing.