### PR TITLE
Switch all remaining builds to ninja or parallel `make`.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,10 +89,7 @@ jobs:
             -DLLVM_USE_SPLIT_DWARF=ON \
             -DLLVM_ENABLE_PROJECTS="clang" \
             ${{github.workspace}}/depsfolder/checkedc-clang/llvm
-          # -l 36: Try not to overload gamera. Hopefully this will use all 36
-          # hyperthreads when nothing else is running and automatically scale
-          # back when other jobs are running. TODO: Better solution?
-          ninja -l 36 3c clang
+          ninja -l $(nproc) 3c clang
           chmod -R 777 ${{github.workspace}}/depsfolder
           chmod -R 777 ${{env.builddir}}
 
@@ -105,7 +102,7 @@ jobs:
       - name: 3C regression tests
         run: |
           cd ${{env.builddir}}
-          ninja check-3c
+          ninja -l $(nproc) check-3c
 
   # Convert our benchmark programs
 
@@ -120,7 +117,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
-          bear make CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
 
       - name: Convert Vsftpd
         run: |
@@ -135,7 +132,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
 
   test_vsftpd_alltypes:
     name: Test Vsftpd (-alltypes)
@@ -148,7 +145,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
-          bear make CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
 
       - name: Convert Vsftpd
         run: |
@@ -164,7 +161,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
 
   test_ptrdist_no_alltypes:
     name: Test PtrDist (no -alltypes)
@@ -178,7 +175,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           for i in anagram bc ft ks yacr2 ; do \
-            (cd $i ; bear make CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
+            (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
 
       - name: Convert anagram
@@ -194,7 +191,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -209,7 +206,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -224,7 +221,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -239,7 +236,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -254,7 +251,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
   test_ptrdist_alltypes:
     name: Test PtrDist (-alltypes)
@@ -268,7 +265,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           for i in anagram bc ft ks yacr2 ; do \
-            (cd $i ; bear make CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
+            (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
 
       - name: Convert anagram
@@ -285,7 +282,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
       - name: Convert bc
         run: |
@@ -301,7 +298,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
       - name: Convert ft
         run: |
@@ -317,7 +314,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
       - name: Convert ks
         run: |
@@ -333,7 +330,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
       - name: Convert yacr2
         run: |
@@ -349,7 +346,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
   test_libarchive_no_alltypes:
     name: Test LibArchive (no -alltypes)
@@ -363,8 +360,8 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
-          bear make archive
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
+          bear ninja -l $(nproc) archive
 
       - name: Convert LibArchive
         run: |
@@ -382,7 +379,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k archive
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_alltypes:
     name: Test LibArchive (-alltypes)
@@ -396,8 +393,8 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
-          bear make archive
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
+          bear ninja -l $(nproc) archive
 
       - name: Convert LibArchive
         run: |
@@ -416,7 +413,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k archive || true
+          ninja -l $(nproc) -k 0 archive || true
 
   test_lua_no_alltypes:
     name: Test Lua (no -alltypes)
@@ -429,7 +426,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
-          bear make CC="${{env.builddir}}/bin/clang" linux
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" linux
           ( cd src ; \
             clang-rename-10 -pl -i \
               --qualified-name=main \
@@ -450,7 +447,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make CC="${{env.builddir}}/bin/clang" -k linux
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
     name: Test Lua (-alltypes)
@@ -463,7 +460,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
-          bear make CC="${{env.builddir}}/bin/clang" linux
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" linux
           ( cd src ; \
             clang-rename-10 -pl -i \
               --qualified-name=main \
@@ -485,7 +482,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make CC="${{env.builddir}}/bin/clang" -k linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:
     name: Test LibTiff (no -alltypes)
@@ -498,8 +495,8 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           cd tiff-4.1.0
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" .
-          bear make tiff
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" .
+          bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
               clang-rename-10 -pl -i \
@@ -523,7 +520,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          make -k tiff
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_alltypes:
     name: Test LibTiff (-alltypes)
@@ -536,8 +533,8 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           cd tiff-4.1.0
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" .
-          bear make tiff
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" .
+          bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
               clang-rename-10 -pl -i \
@@ -562,7 +559,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          make -k tiff || true
+          ninja -l $(nproc) -k 0 tiff || true
 
   test_zlib_no_alltypes:
     name: Test ZLib (no -alltypes)
@@ -577,8 +574,8 @@ jobs:
           cd zlib-1.2.11
           mkdir build
           cd build
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" ..
-          bear make zlib
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" ..
+          bear ninja -l $(nproc) zlib
 
       - name: Convert ZLib
         run: |
@@ -596,7 +593,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k zlib
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_alltypes:
     name: Test ZLib (-alltypes)
@@ -611,8 +608,8 @@ jobs:
           cd zlib-1.2.11
           mkdir build
           cd build
-          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -DCMAKE_C_FLAGS="-w" ..
-          bear make zlib
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" ..
+          bear ninja -l $(nproc) zlib
 
       - name: Convert ZLib
         run: |
@@ -631,7 +628,7 @@ jobs:
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          make -k zlib || true
+          ninja -l $(nproc) -k 0 zlib || true
 
   test_icecast_no_alltypes:
     name: Test Icecast (no -alltypes)
@@ -645,7 +642,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           CC="${{env.builddir}}/bin/clang" ./configure
-          bear make
+          bear make -j $(nproc) -l $(nproc) --output-sync
 
       - name: Convert Icecast
         run: |
@@ -660,7 +657,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -k
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_alltypes:
     name: Test Icecast (-alltypes)
@@ -674,7 +671,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           CC="${{env.builddir}}/bin/clang" ./configure
-          bear make
+          bear make -j $(nproc) -l $(nproc) --output-sync
 
       - name: Convert Icecast
         run: |
@@ -690,4 +687,4 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k || true


### PR DESCRIPTION
This should speed up the workflow a bit in preparation for running the benchmarks both with and without prior macro expansion, though convert_project is single-threaded and continues to take a significant fraction of the time.

Also standardize on `-l $(nproc)` to try to avoid overloading the machine.

Addresses #8.

[Workflow run](https://github.com/correctcomputation/actions/actions/runs/687843017): looks as good as [before](https://github.com/correctcomputation/actions/actions/runs/687594105), and the running time is reduced from 20 to 18 minutes.  (It was more impressive when the reduction was from 23 to 18 minutes before John fixed the build targets in #12, but this PR is all ready to go and addresses the issue where `make -k` didn't show us all the errors for CMake projects in case that becomes relevant again in the future, so let's still merge it. :slightly_smiling_face:)