### PR TITLE
Run the benchmarks with and without expanding macros before calling 3C.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -152,7 +151,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -182,9 +180,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Vsftpd
@@ -211,10 +209,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Vsftpd (ignore failure)
@@ -243,7 +241,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -259,7 +256,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -275,7 +271,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -291,7 +286,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -307,7 +301,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -338,7 +331,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -355,7 +347,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -372,7 +363,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -389,7 +379,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -406,7 +395,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -438,9 +426,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted anagram
@@ -454,9 +442,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted bc
@@ -470,9 +458,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted ft
@@ -486,9 +474,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted ks
@@ -502,9 +490,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted yacr2
@@ -533,10 +521,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted anagram (ignore failure)
@@ -550,10 +538,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted bc (ignore failure)
@@ -567,10 +555,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted ft (ignore failure)
@@ -584,10 +572,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted ks (ignore failure)
@@ -601,10 +589,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted yacr2 (ignore failure)
@@ -634,7 +622,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -668,7 +655,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -703,9 +689,9 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path . \
             --build_dir build
 
@@ -737,10 +723,10 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path . \
             --build_dir build
 
@@ -774,7 +760,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -809,7 +794,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -845,9 +829,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Lua
@@ -880,10 +864,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Lua (ignore failure)
@@ -921,7 +905,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -960,7 +943,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -1000,9 +982,9 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted LibTiff
@@ -1039,10 +1021,10 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted LibTiff (ignore failure)
@@ -1073,7 +1055,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -1108,7 +1089,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -1144,9 +1124,9 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path . \
             --build_dir build
 
@@ -1179,10 +1159,10 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path . \
             --build_dir build
 
@@ -1212,7 +1192,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -1242,7 +1221,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -1273,9 +1251,9 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Icecast
@@ -1303,10 +1281,10 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
+            --expand_macros_before_conversion \
             --project_path .
 
       - name: Build converted Icecast (ignore failure)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
   # Convert our benchmark programs
 
   test_vsftpd_no_alltypes:
-    name: Test Vsftpd (preprocessed, no -alltypes)
+    name: Test Vsftpd (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -123,7 +123,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -136,7 +136,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
 
   test_vsftpd_alltypes:
-    name: Test Vsftpd (preprocessed, -alltypes)
+    name: Test Vsftpd (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -152,7 +152,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -166,7 +166,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
 
   test_ptrdist_no_alltypes:
-    name: Test PtrDist (preprocessed, no -alltypes)
+    name: Test PtrDist (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -184,7 +184,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -200,7 +200,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -216,7 +216,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -232,7 +232,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -248,7 +248,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -261,7 +261,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
   test_ptrdist_alltypes:
-    name: Test PtrDist (preprocessed, -alltypes)
+    name: Test PtrDist (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -279,7 +279,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -296,7 +296,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -313,7 +313,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -330,7 +330,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -347,7 +347,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -361,7 +361,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
   test_libarchive_no_alltypes:
-    name: Test LibArchive (preprocessed, no -alltypes)
+    name: Test LibArchive (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -380,7 +380,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -395,7 +395,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive
 
   test_libarchive_alltypes:
-    name: Test LibArchive (preprocessed, -alltypes)
+    name: Test LibArchive (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -414,7 +414,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -430,7 +430,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive || true
 
   test_lua_no_alltypes:
-    name: Test Lua (preprocessed, no -alltypes)
+    name: Test Lua (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -451,7 +451,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -465,7 +465,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
-    name: Test Lua (preprocessed, -alltypes)
+    name: Test Lua (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -486,7 +486,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -501,7 +501,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:
-    name: Test LibTiff (preprocessed, no -alltypes)
+    name: Test LibTiff (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -527,7 +527,7 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -540,7 +540,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_alltypes:
-    name: Test LibTiff (preprocessed, -alltypes)
+    name: Test LibTiff (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -566,7 +566,7 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -580,7 +580,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff || true
 
   test_zlib_no_alltypes:
-    name: Test ZLib (preprocessed, no -alltypes)
+    name: Test ZLib (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -600,7 +600,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -615,7 +615,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib
 
   test_zlib_alltypes:
-    name: Test ZLib (preprocessed, -alltypes)
+    name: Test ZLib (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -635,7 +635,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -651,7 +651,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib || true
 
   test_icecast_no_alltypes:
-    name: Test Icecast (preprocessed, no -alltypes)
+    name: Test Icecast (macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -668,7 +668,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -681,7 +681,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_alltypes:
-    name: Test Icecast (preprocessed, -alltypes)
+    name: Test Icecast (macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -698,7 +698,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --preprocess_before_conversion \
+            --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
   # Convert our benchmark programs
 
   test_vsftpd_no_alltypes:
-    name: Test Vsftpd (no -alltypes)
+    name: Test Vsftpd (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -136,7 +136,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
 
   test_vsftpd_alltypes:
-    name: Test Vsftpd (-alltypes)
+    name: Test Vsftpd (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -225,7 +225,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
 
   test_ptrdist_no_alltypes:
-    name: Test PtrDist (no -alltypes)
+    name: Test PtrDist (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -320,7 +320,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
   test_ptrdist_alltypes:
-    name: Test PtrDist (-alltypes)
+    name: Test PtrDist (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -615,7 +615,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
   test_libarchive_no_alltypes:
-    name: Test LibArchive (no -alltypes)
+    name: Test LibArchive (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -649,7 +649,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive
 
   test_libarchive_alltypes:
-    name: Test LibArchive (-alltypes)
+    name: Test LibArchive (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -753,7 +753,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive || true
 
   test_lua_no_alltypes:
-    name: Test Lua (no -alltypes)
+    name: Test Lua (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -788,7 +788,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
-    name: Test Lua (-alltypes)
+    name: Test Lua (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -895,7 +895,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:
-    name: Test LibTiff (no -alltypes)
+    name: Test LibTiff (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -934,7 +934,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_alltypes:
-    name: Test LibTiff (-alltypes)
+    name: Test LibTiff (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -1053,7 +1053,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff || true
 
   test_zlib_no_alltypes:
-    name: Test ZLib (no -alltypes)
+    name: Test ZLib (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -1088,7 +1088,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib
 
   test_zlib_alltypes:
-    name: Test ZLib (-alltypes)
+    name: Test ZLib (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -1195,7 +1195,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib || true
 
   test_icecast_no_alltypes:
-    name: Test Icecast (no -alltypes)
+    name: Test Icecast (not macro-expanded, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -1225,7 +1225,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_alltypes:
-    name: Test Icecast (-alltypes)
+    name: Test Icecast (not macro-expanded, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,21 +107,21 @@ jobs:
   # Convert our benchmark programs
 
   test_vsftpd_no_alltypes:
-    name: Test Vsftpd (macro-expanded, no -alltypes)
+    name: Test Vsftpd (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build Vsftpd
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
 
       - name: Convert Vsftpd
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -130,13 +130,13 @@ jobs:
 
       - name: Build converted Vsftpd
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
 
   test_vsftpd_alltypes:
-    name: Test Vsftpd (macro-expanded, -alltypes)
+    name: Test Vsftpd (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -165,15 +165,74 @@ jobs:
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
 
+  test_vsftpd_expand_macros_no_alltypes:
+    name: Test Vsftpd (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Vsftpd
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
+          cd vsftpd-3.0.3
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
+
+      - name: Convert Vsftpd
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted Vsftpd
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
+
+  test_vsftpd_expand_macros_alltypes:
+    name: Test Vsftpd (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Vsftpd
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
+          cd vsftpd-3.0.3
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion"
+
+      - name: Convert Vsftpd
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted Vsftpd (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
+
   test_ptrdist_no_alltypes:
-    name: Test PtrDist (macro-expanded, no -alltypes)
+    name: Test PtrDist (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build PtrDist
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           for i in anagram bc ft ks yacr2 ; do \
@@ -182,7 +241,7 @@ jobs:
 
       - name: Convert anagram
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -191,14 +250,14 @@ jobs:
 
       - name: Build converted anagram
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -207,14 +266,14 @@ jobs:
 
       - name: Build converted bc
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -223,14 +282,14 @@ jobs:
 
       - name: Build converted ft
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -239,14 +298,14 @@ jobs:
 
       - name: Build converted ks
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -255,13 +314,13 @@ jobs:
 
       - name: Build converted yacr2
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
   test_ptrdist_alltypes:
-    name: Test PtrDist (macro-expanded, -alltypes)
+    name: Test PtrDist (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -360,15 +419,210 @@ jobs:
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
+  test_ptrdist_expand_macros_no_alltypes:
+    name: Test PtrDist (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build PtrDist
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
+          cd ptrdist-1.1
+          for i in anagram bc ft ks yacr2 ; do \
+            (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
+          done
+
+      - name: Convert anagram
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted anagram
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+
+      - name: Convert bc
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted bc
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+
+      - name: Convert ft
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted ft
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+
+      - name: Convert ks
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted ks
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+
+      - name: Convert yacr2
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted yacr2
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
+
+  test_ptrdist_expand_macros_alltypes:
+    name: Test PtrDist (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build PtrDist
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
+          cd ptrdist-1.1
+          for i in anagram bc ft ks yacr2 ; do \
+            (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
+          done
+
+      - name: Convert anagram
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted anagram (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+
+      - name: Convert bc
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted bc (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+
+      - name: Convert ft
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted ft (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+
+      - name: Convert ks
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted ks (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+
+      - name: Convert yacr2
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted yacr2 (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
+
   test_libarchive_no_alltypes:
-    name: Test LibArchive (macro-expanded, no -alltypes)
+    name: Test LibArchive (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build LibArchive
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -377,7 +631,7 @@ jobs:
 
       - name: Convert LibArchive
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
             --expand_macros_before_conversion \
@@ -388,14 +642,14 @@ jobs:
 
       - name: Build converted LibArchive
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
           ninja -l $(nproc) -k 0 archive
 
   test_libarchive_alltypes:
-    name: Test LibArchive (macro-expanded, -alltypes)
+    name: Test LibArchive (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -429,15 +683,84 @@ jobs:
           cd build
           ninja -l $(nproc) -k 0 archive || true
 
+  test_libarchive_expand_macros_no_alltypes:
+    name: Test LibArchive (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build LibArchive
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
+          cd libarchive-3.4.3
+          cd build
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
+          bear ninja -l $(nproc) archive
+
+      - name: Convert LibArchive
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path . \
+            --build_dir build
+
+      - name: Build converted LibArchive
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
+          cp -r out.checked/* .
+          rm -r out.checked
+          cd build
+          ninja -l $(nproc) -k 0 archive
+
+  test_libarchive_expand_macros_alltypes:
+    name: Test LibArchive (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build LibArchive
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
+          cd libarchive-3.4.3
+          cd build
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w -D_GNU_SOURCE" ..
+          bear ninja -l $(nproc) archive
+
+      - name: Convert LibArchive
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path . \
+            --build_dir build
+
+      - name: Build converted LibArchive (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
+          cp -r out.checked/* .
+          rm -r out.checked
+          cd build
+          ninja -l $(nproc) -k 0 archive || true
+
   test_lua_no_alltypes:
-    name: Test Lua (macro-expanded, no -alltypes)
+    name: Test Lua (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build Lua
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" linux
@@ -449,7 +772,7 @@ jobs:
 
       - name: Convert Lua
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -458,14 +781,14 @@ jobs:
 
       - name: Build converted Lua
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
-    name: Test Lua (macro-expanded, -alltypes)
+    name: Test Lua (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -500,15 +823,86 @@ jobs:
           sed -i "s/luac_main/main/" src/luac.c
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
 
+  test_lua_expand_macros_no_alltypes:
+    name: Test Lua (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Lua
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
+          cd lua-5.4.1
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" linux
+          ( cd src ; \
+            clang-rename-10 -pl -i \
+              --qualified-name=main \
+              --new-name=luac_main \
+              luac.c )
+
+      - name: Convert Lua
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted Lua
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
+          cp -r out.checked/* .
+          rm -r out.checked
+          sed -i "s/luac_main/main/" src/luac.c
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
+
+  test_lua_expand_macros_alltypes:
+    name: Test Lua (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Lua
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
+          cd lua-5.4.1
+          bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" linux
+          ( cd src ; \
+            clang-rename-10 -pl -i \
+              --qualified-name=main \
+              --new-name=luac_main \
+              luac.c )
+
+      - name: Convert Lua
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted Lua (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
+          cp -r out.checked/* .
+          rm -r out.checked
+          sed -i "s/luac_main/main/" src/luac.c
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
+
   test_libtiff_no_alltypes:
-    name: Test LibTiff (macro-expanded, no -alltypes)
+    name: Test LibTiff (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build LibTiff
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           cd tiff-4.1.0
           cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" .
@@ -522,7 +916,7 @@ jobs:
 
       - name: Convert LibTiff
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/tiff-4.1.0
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
@@ -534,13 +928,13 @@ jobs:
 
       - name: Build converted LibTiff
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/tiff-4.1.0
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
           ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_alltypes:
-    name: Test LibTiff (macro-expanded, -alltypes)
+    name: Test LibTiff (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -579,15 +973,94 @@ jobs:
           rm -r out.checked
           ninja -l $(nproc) -k 0 tiff || true
 
+  test_libtiff_expand_macros_no_alltypes:
+    name: Test LibTiff (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build LibTiff
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
+          cd tiff-4.1.0
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" .
+          bear ninja -l $(nproc) tiff
+          ( cd tools ; \
+            for i in *.c ; do \
+              clang-rename-10 -pl -i \
+                --qualified-name=main \
+                --new-name=$(basename -s .c $i)_main $i ; \
+            done)
+
+      - name: Convert LibTiff
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/tiff-4.1.0
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/tif_stream.cxx' \
+            --skip '.*/test/.*\.c' \
+            --skip '.*/contrib/.*\.c' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted LibTiff
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/tiff-4.1.0
+          cp -r out.checked/* .
+          rm -r out.checked
+          ninja -l $(nproc) -k 0 tiff
+
+  test_libtiff_expand_macros_alltypes:
+    name: Test LibTiff (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build LibTiff
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
+          cd tiff-4.1.0
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" .
+          bear ninja -l $(nproc) tiff
+          ( cd tools ; \
+            for i in *.c ; do \
+              clang-rename-10 -pl -i \
+                --qualified-name=main \
+                --new-name=$(basename -s .c $i)_main $i ; \
+            done)
+
+      - name: Convert LibTiff
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/tif_stream.cxx' \
+            --skip '.*/test/.*\.c' \
+            --skip '.*/contrib/.*\.c' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted LibTiff (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
+          cp -r out.checked/* .
+          rm -r out.checked
+          ninja -l $(nproc) -k 0 tiff || true
+
   test_zlib_no_alltypes:
-    name: Test ZLib (macro-expanded, no -alltypes)
+    name: Test ZLib (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build ZLib
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -597,7 +1070,7 @@ jobs:
 
       - name: Convert ZLib
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
             --expand_macros_before_conversion \
@@ -608,14 +1081,14 @@ jobs:
 
       - name: Build converted ZLib
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
           ninja -l $(nproc) -k 0 zlib
 
   test_zlib_alltypes:
-    name: Test ZLib (macro-expanded, -alltypes)
+    name: Test ZLib (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -650,15 +1123,86 @@ jobs:
           cd build
           ninja -l $(nproc) -k 0 zlib || true
 
+  test_zlib_expand_macros_no_alltypes:
+    name: Test ZLib (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build ZLib
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
+          cd zlib-1.2.11
+          mkdir build
+          cd build
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" ..
+          bear ninja -l $(nproc) zlib
+
+      - name: Convert ZLib
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/test/.*' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path . \
+            --build_dir build
+
+      - name: Build converted ZLib
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
+          cp -r out.checked/* .
+          rm -r out.checked
+          cd build
+          ninja -l $(nproc) -k 0 zlib
+
+  test_zlib_expand_macros_alltypes:
+    name: Test ZLib (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build ZLib
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
+          cd zlib-1.2.11
+          mkdir build
+          cd build
+          cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang -G Ninja -DCMAKE_C_FLAGS="-w" ..
+          bear ninja -l $(nproc) zlib
+
+      - name: Convert ZLib
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
+          ${{env.port_tools}}/convert_project.py \
+            --skip '/.*/test/.*' \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path . \
+            --build_dir build
+
+      - name: Build converted ZLib (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
+          cp -r out.checked/* .
+          rm -r out.checked
+          cd build
+          ninja -l $(nproc) -k 0 zlib || true
+
   test_icecast_no_alltypes:
-    name: Test Icecast (macro-expanded, no -alltypes)
+    name: Test Icecast (no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
       - name: Build Icecast
         run: |
-          mkdir -p ${{env.benchmark_conv_dir}}/no-alltypes
-          cd ${{env.benchmark_conv_dir}}/no-alltypes
+          mkdir -p ${{env.benchmark_conv_dir}}/no_alltypes
+          cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           CC="${{env.builddir}}/bin/clang" ./configure
@@ -666,7 +1210,7 @@ jobs:
 
       - name: Convert Icecast
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
             --expand_macros_before_conversion \
             --includeDir ${{env.include_dir}} \
@@ -675,13 +1219,13 @@ jobs:
 
       - name: Build converted Icecast
         run: |
-          cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
+          cd ${{env.benchmark_conv_dir}}/no_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_alltypes:
-    name: Test Icecast (macro-expanded, -alltypes)
+    name: Test Icecast (-alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -707,6 +1251,67 @@ jobs:
       - name: Build converted Icecast (ignore failure)
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync -k || true
+
+  test_icecast_expand_macros_no_alltypes:
+    name: Test Icecast (macro-expanded, no -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Icecast
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
+          cd icecast-2.4.4
+          CC="${{env.builddir}}/bin/clang" ./configure
+          bear make -j $(nproc) -l $(nproc) --output-sync
+
+      - name: Convert Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --project_path .
+
+      - name: Build converted Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
+          cp -r out.checked/* .
+          rm -r out.checked
+          make -j $(nproc) -l $(nproc) --output-sync -k
+
+  test_icecast_expand_macros_alltypes:
+    name: Test Icecast (macro-expanded, -alltypes)
+    needs: build_3c
+    runs-on: self-hosted
+    steps:
+      - name: Build Icecast
+        run: |
+          mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
+          cd icecast-2.4.4
+          CC="${{env.builddir}}/bin/clang" ./configure
+          bear make -j $(nproc) -l $(nproc) --output-sync
+
+      - name: Convert Icecast
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
+          ${{env.port_tools}}/convert_project.py \
+            --expand_macros_before_conversion \
+            --includeDir ${{env.include_dir}} \
+            --prog_name ${{env.builddir}}/bin/3c \
+            --extra-3c-arg=-alltypes \
+            --project_path .
+
+      - name: Build converted Icecast (ignore failure)
+        run: |
+          cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
           make -j $(nproc) -l $(nproc) --output-sync -k || true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,7 +107,7 @@ jobs:
   # Convert our benchmark programs
 
   test_vsftpd_no_alltypes:
-    name: Test Vsftpd (no -alltypes)
+    name: Test Vsftpd (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -123,6 +123,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -135,7 +136,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k
 
   test_vsftpd_alltypes:
-    name: Test Vsftpd (-alltypes)
+    name: Test Vsftpd (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -151,6 +152,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -164,7 +166,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -Wno-enum-conversion" -k || true
 
   test_ptrdist_no_alltypes:
-    name: Test PtrDist (no -alltypes)
+    name: Test PtrDist (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -182,6 +184,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -197,6 +200,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -212,6 +216,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -227,6 +232,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -242,6 +248,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -254,7 +261,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE"
 
   test_ptrdist_alltypes:
-    name: Test PtrDist (-alltypes)
+    name: Test PtrDist (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -272,6 +279,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -288,6 +296,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -304,6 +313,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -320,6 +330,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -336,6 +347,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -349,7 +361,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-D_ISOC99_SOURCE" || true
 
   test_libarchive_no_alltypes:
-    name: Test LibArchive (no -alltypes)
+    name: Test LibArchive (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -368,6 +380,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -382,7 +395,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive
 
   test_libarchive_alltypes:
-    name: Test LibArchive (-alltypes)
+    name: Test LibArchive (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -401,6 +414,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -416,7 +430,7 @@ jobs:
           ninja -l $(nproc) -k 0 archive || true
 
   test_lua_no_alltypes:
-    name: Test Lua (no -alltypes)
+    name: Test Lua (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -437,6 +451,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -450,7 +465,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux
 
   test_lua_alltypes:
-    name: Test Lua (-alltypes)
+    name: Test Lua (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -471,6 +486,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -485,7 +501,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k linux || true
 
   test_libtiff_no_alltypes:
-    name: Test LibTiff (no -alltypes)
+    name: Test LibTiff (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -511,6 +527,7 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -523,7 +540,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_alltypes:
-    name: Test LibTiff (-alltypes)
+    name: Test LibTiff (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -549,6 +566,7 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -562,7 +580,7 @@ jobs:
           ninja -l $(nproc) -k 0 tiff || true
 
   test_zlib_no_alltypes:
-    name: Test ZLib (no -alltypes)
+    name: Test ZLib (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -582,6 +600,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no-alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
@@ -596,7 +615,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib
 
   test_zlib_alltypes:
-    name: Test ZLib (-alltypes)
+    name: Test ZLib (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -616,6 +635,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
@@ -631,7 +651,7 @@ jobs:
           ninja -l $(nproc) -k 0 zlib || true
 
   test_icecast_no_alltypes:
-    name: Test Icecast (no -alltypes)
+    name: Test Icecast (preprocessed, no -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -648,6 +668,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no-alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
@@ -660,7 +681,7 @@ jobs:
           make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_alltypes:
-    name: Test Icecast (-alltypes)
+    name: Test Icecast (preprocessed, -alltypes)
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -677,6 +698,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
+            --preprocess_before_conversion \
             --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -331,10 +331,13 @@ with open('.github/workflows/main.yml', 'w') as out:
     out.write(HEADER)
     for binfo in benchmarks:
         for alltypes in (False, True):
+            preprocess_before_conversion = True
             at_dir = ('${{env.benchmark_conv_dir}}/' +
                       ('alltypes' if alltypes else 'no-alltypes'))
             at_job = 'alltypes' if alltypes else 'no_alltypes'
             at_job_friendly = '-alltypes' if alltypes else 'no -alltypes'
+            pbc_job_friendly = ('preprocessed, '
+                                if preprocess_before_conversion else '')
             convert_extra = (ensure_trailing_newline(binfo.convert_extra)
                              if binfo.convert_extra is not None else '')
             build_converted_cmd = binfo.build_converted_cmd.rstrip('\n')
@@ -347,7 +350,7 @@ with open('.github/workflows/main.yml', 'w') as out:
             out.write(f'''\
 
   test_{binfo.name}_{at_job}:
-    name: Test {binfo.friendly_name} ({at_job_friendly})
+    name: Test {binfo.friendly_name} ({pbc_job_friendly}{at_job_friendly})
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -376,6 +379,7 @@ with open('.github/workflows/main.yml', 'w') as out:
                 # yapf: disable
                 convert_flags = textwrap.indent(
                     convert_extra +
+                    '--preprocess_before_conversion \\\n' +
                     '--includeDir ${{env.include_dir}} \\\n' +
                     '--prog_name ${{env.builddir}}/bin/3c \\\n' +
                     at_flag +

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -345,6 +345,8 @@ with open('.github/workflows/main.yml', 'w') as out:
             # Python argparse thinks `--extra-3c-arg -alltypes` is two options
             # rather than an option with an argument.
             at_flag = '--extra-3c-arg=-alltypes \\\n' if alltypes else ''
+            embc_flag = ('--expand_macros_before_conversion \\\n'
+                         if expand_macros else '')
             at_ignore_step = ' (ignore failure)' if alltypes else ''
             at_ignore_code = ' || true' if alltypes else ''
 
@@ -380,10 +382,9 @@ with open('.github/workflows/main.yml', 'w') as out:
                 # yapf: disable
                 convert_flags = textwrap.indent(
                     convert_extra +
-                    '--expand_macros_before_conversion \\\n' +
                     '--includeDir ${{env.include_dir}} \\\n' +
                     '--prog_name ${{env.builddir}}/bin/3c \\\n' +
-                    at_flag +
+                    at_flag + embc_flag +
                     '--project_path .' +
                     (f' \\\n--build_dir {component.build_dir}'
                      if component.build_dir is not None else '') +

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -331,13 +331,13 @@ with open('.github/workflows/main.yml', 'w') as out:
     out.write(HEADER)
     for binfo in benchmarks:
         for alltypes in (False, True):
-            preprocess_before_conversion = True
+            expand_macros_before_conversion = True
             at_dir = ('${{env.benchmark_conv_dir}}/' +
                       ('alltypes' if alltypes else 'no-alltypes'))
             at_job = 'alltypes' if alltypes else 'no_alltypes'
             at_job_friendly = '-alltypes' if alltypes else 'no -alltypes'
-            pbc_job_friendly = ('preprocessed, '
-                                if preprocess_before_conversion else '')
+            embc_job_friendly = ('macro-expanded, '
+                                 if expand_macros_before_conversion else '')
             convert_extra = (ensure_trailing_newline(binfo.convert_extra)
                              if binfo.convert_extra is not None else '')
             build_converted_cmd = binfo.build_converted_cmd.rstrip('\n')
@@ -350,7 +350,7 @@ with open('.github/workflows/main.yml', 'w') as out:
             out.write(f'''\
 
   test_{binfo.name}_{at_job}:
-    name: Test {binfo.friendly_name} ({pbc_job_friendly}{at_job_friendly})
+    name: Test {binfo.friendly_name} ({embc_job_friendly}{at_job_friendly})
     needs: build_3c
     runs-on: self-hosted
     steps:
@@ -379,7 +379,7 @@ with open('.github/workflows/main.yml', 'w') as out:
                 # yapf: disable
                 convert_flags = textwrap.indent(
                     convert_extra +
-                    '--preprocess_before_conversion \\\n' +
+                    '--expand_macros_before_conversion \\\n' +
                     '--includeDir ${{env.include_dir}} \\\n' +
                     '--prog_name ${{env.builddir}}/bin/3c \\\n' +
                     at_flag +

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -335,8 +335,9 @@ with open('.github/workflows/main.yml', 'w') as out:
                                                          (False, True)):
             variant = (('expand_macros_' if expand_macros else '') +
                        ('alltypes' if alltypes else 'no_alltypes'))
-            variant_friendly = (('macro-expanded, ' if expand_macros else '') +
-                                ('-alltypes' if alltypes else 'no -alltypes'))
+            variant_friendly = (('' if expand_macros else 'not ') +
+                                'macro-expanded, ' +
+                                ('' if alltypes else 'no ') + '-alltypes')
             variant_dir = '${{env.benchmark_conv_dir}}/' + variant
             convert_extra = (ensure_trailing_newline(binfo.convert_extra)
                              if binfo.convert_extra is not None else '')


### PR DESCRIPTION
A relatively straightforward workflow change that depends on correctcomputation/checkedc-clang#516, where the interesting logic lives.