### PR TITLE
Patch Yacr2 to work around 3c issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,8 +236,10 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
+              new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              cp "$header" "$new_header"
+              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -332,8 +334,10 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
+              new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              cp "$header" "$new_header"
+              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -433,8 +437,10 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
+              new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              cp "$header" "$new_header"
+              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -534,8 +540,10 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
+              new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              cp "$header" "$new_header"
+              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -236,8 +236,8 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
-              test "$src" -e || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              test -e "$src" || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -332,8 +332,8 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
-              test "$src" -e || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              test -e "$src" || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -433,8 +433,8 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
-              test "$src" -e || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              test -e "$src" || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -534,8 +534,8 @@ jobs:
           ( cd yacr2 ; \
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
-              test "$src" -e || continue
-              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+              test -e "$src" || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,7 +233,12 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
-          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
+          ( cd yacr2 ; \
+            for header in *.h  ; do
+              src="$(basename "$header" .h).c"
+              test "$src" -e || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+            done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -324,7 +329,12 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
-          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
+          ( cd yacr2 ; \
+            for header in *.h  ; do
+              src="$(basename "$header" .h).c"
+              test "$src" -e || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+            done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -420,7 +430,12 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
-          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
+          ( cd yacr2 ; \
+            for header in *.h  ; do
+              src="$(basename "$header" .h).c"
+              test "$src" -e || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+            done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -516,7 +531,12 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
-          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
+          ( cd yacr2 ; \
+            for header in *.h  ; do
+              src="$(basename "$header" .h).c"
+              test "$src" -e || continue
+              sed -f <( echo -n "s/#include \"$header\"/" ; sed 's/\//\\//g' "$header" | awk 1 ORS='\\n' ; echo '/' ) -i "$src"
+            done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -233,6 +233,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
+          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -323,6 +324,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
+          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -418,6 +420,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
+          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done
@@ -513,6 +516,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
+          (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
           done

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -91,6 +91,13 @@ benchmarks = [
         name='ptrdist',
         friendly_name='PtrDist',
         dir_name='ptrdist-1.1',
+        # Patch yacr2 to work around correctcomputation/checkedc-clang#374.
+        # For each header file, the translation unit for the corresponding
+        # source files defines a macro *_CODE that causes the preprocessesor to
+        # take a different branch. To avoid issues that arise when rewriting is
+        # required in both branches in a single file, we create copies of the
+        # header files that are included only by the single source file that
+        # defines the relevant *_CODE macro.
         build_cmds=textwrap.dedent(f'''\
         ( cd yacr2 ; \\
           for header in *.h  ; do

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -92,7 +92,12 @@ benchmarks = [
         friendly_name='PtrDist',
         dir_name='ptrdist-1.1',
         build_cmds=textwrap.dedent(f'''\
-        (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
+        ( cd yacr2 ; \\
+          for header in *.h  ; do
+            src="$(basename "$header" .h).c"
+            test "$src" -e || continue
+            sed -f <( echo -n "s/#include \\"$header\\"/" ; sed 's/\\//\\\\//g' "$header" | awk 1 ORS='\\\\n' ; echo '/' ) -i "$src"
+          done )
         for i in {' '.join(ptrdist_components)} ; do \\
           (cd $i ; bear {make_checkedc} LOCAL_CFLAGS="-D_ISOC99_SOURCE") \\
         done

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -92,6 +92,7 @@ benchmarks = [
         friendly_name='PtrDist',
         dir_name='ptrdist-1.1',
         build_cmds=textwrap.dedent(f'''\
+        (cd yacr2 ; sed -i '/#define.*_CODE/d' *.c)
         for i in {' '.join(ptrdist_components)} ; do \\
           (cd $i ; bear {make_checkedc} LOCAL_CFLAGS="-D_ISOC99_SOURCE") \\
         done

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -95,8 +95,10 @@ benchmarks = [
         ( cd yacr2 ; \\
           for header in *.h  ; do
             src="$(basename "$header" .h).c"
+            new_header="$(basename "$header" .h)_code.h"
             test -e "$src" || continue
-            sed -f <( echo -n "s/#include \\"$header\\"/" ; sed 's/\\//\\\\\\//g' "$header" | awk 1 ORS='\\\\n' ; echo '/' ) -i "$src"
+            cp "$header" "$new_header"
+            sed -i "s/#include \\"$header\\"/#include \\"$new_header\\"/" "$src"
           done )
         for i in {' '.join(ptrdist_components)} ; do \\
           (cd $i ; bear {make_checkedc} LOCAL_CFLAGS="-D_ISOC99_SOURCE") \\

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -95,8 +95,8 @@ benchmarks = [
         ( cd yacr2 ; \\
           for header in *.h  ; do
             src="$(basename "$header" .h).c"
-            test "$src" -e || continue
-            sed -f <( echo -n "s/#include \\"$header\\"/" ; sed 's/\\//\\\\//g' "$header" | awk 1 ORS='\\\\n' ; echo '/' ) -i "$src"
+            test -e "$src" || continue
+            sed -f <( echo -n "s/#include \\"$header\\"/" ; sed 's/\\//\\\\\\//g' "$header" | awk 1 ORS='\\\\n' ; echo '/' ) -i "$src"
           done )
         for i in {' '.join(ptrdist_components)} ; do \\
           (cd $i ; bear {make_checkedc} LOCAL_CFLAGS="-D_ISOC99_SOURCE") \\


### PR DESCRIPTION
Patches Yacr2 to work around correctcomputation/checkedc-clang#374. For each header file, the translation unit for the corresponding source files defines a macro `*_CODE` that causes the preprocessesor to take a different branch. To avoid issue s when rewriting is required in both branches, this PR creates a second copy of the header files that are included only by the source files that define the `*_CODE` macro.

[workflow run](https://github.com/correctcomputation/actions/runs/2248739105)