### PR TITLE
Improve the yacr2 workaround to avoid duplicating structs and typedefs in multiple files.

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -456,6 +456,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -619,6 +620,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -787,6 +789,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -955,6 +958,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -1123,6 +1127,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -1291,6 +1296,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -1464,6 +1470,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -1637,6 +1644,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"

--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -460,8 +460,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -623,8 +623,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -791,8 +791,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -959,8 +959,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -1127,8 +1127,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -1295,8 +1295,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -1468,8 +1468,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -1641,8 +1641,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -238,8 +238,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -336,8 +336,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -439,8 +439,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \
@@ -542,8 +542,8 @@ jobs:
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
               test -e "$src" || continue
-              cp "$header" "$new_header"
-              sed -i "s/#include \"$header\"/#include \"$new_header\"/" "$src"
+              sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{ /^#/!p; }' "$header" >"$new_header"
+              sed -i "/#define.*_CODE/d; /#include \"$header\"/a#include \"$new_header\"" "$src"
             done )
           for i in anagram bc ft ks yacr2 ; do \
             (cd $i ; bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" LOCAL_CFLAGS="-D_ISOC99_SOURCE") \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -234,6 +234,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -332,6 +333,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -435,6 +437,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"
@@ -538,6 +541,7 @@ jobs:
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2 ; \
+            sed -Ei 's/^long (.*costMatrix)/ulong \1/' assign.h
             for header in *.h  ; do
               src="$(basename "$header" .h).c"
               new_header="$(basename "$header" .h)_code.h"

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -104,8 +104,12 @@ benchmarks = [
         # simulate the normal practice by copying only the parts of foo.h
         # conditional on FOO_CODE to a new file foo_code.h, making foo.c include
         # foo_code.h in addition to foo.h, and deleting the `#define FOO_CODE`.
+        #
+        # Also fix type conflict between `costMatrix` declaration and
+        # definition, exposed when both are in the same translation unit.
         build_cmds=textwrap.dedent(f'''\
         ( cd yacr2 ; \\
+          sed -Ei 's/^long (.*costMatrix)/ulong \\1/' assign.h
           for header in *.h  ; do
             src="$(basename "$header" .h).c"
             new_header="$(basename "$header" .h)_code.h"

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -95,21 +95,23 @@ benchmarks = [
         name='ptrdist',
         friendly_name='PtrDist',
         dir_name='ptrdist-1.1',
-        # Patch yacr2 to work around correctcomputation/checkedc-clang#374.
-        # For each header file, the translation unit for the corresponding
-        # source files defines a macro *_CODE that causes the preprocessesor to
-        # take a different branch. To avoid issues that arise when rewriting is
-        # required in both branches in a single file, we create copies of the
-        # header files that are included only by the single source file that
-        # defines the relevant *_CODE macro.
+        # Patch yacr2 to work around correctcomputation/checkedc-clang#374. For
+        # certain header files foo.h, foo.c defines a macro FOO_CODE that
+        # activates a different #if branch in foo.h that defines global
+        # variables instead of declaring them. This is an unusual practice:
+        # normally foo.h would declare the variables whether or not it is being
+        # included by foo.c, and then foo.c would additionally define them. We
+        # simulate the normal practice by copying only the parts of foo.h
+        # conditional on FOO_CODE to a new file foo_code.h, making foo.c include
+        # foo_code.h in addition to foo.h, and deleting the `#define FOO_CODE`.
         build_cmds=textwrap.dedent(f'''\
         ( cd yacr2 ; \\
           for header in *.h  ; do
             src="$(basename "$header" .h).c"
             new_header="$(basename "$header" .h)_code.h"
             test -e "$src" || continue
-            cp "$header" "$new_header"
-            sed -i "s/#include \\"$header\\"/#include \\"$new_header\\"/" "$src"
+            sed -ne '/^#ifdef.*CODE/,/#else.*CODE/{{ /^#/!p; }}' "$header" >"$new_header"
+            sed -i "/#define.*_CODE/d; /#include \\"$header\\"/a#include \\"$new_header\\"" "$src"
           done )
         for i in {' '.join(ptrdist_components)} ; do \\
           (cd $i ; bear {make_checkedc} LOCAL_CFLAGS="-D_ISOC99_SOURCE") \\


### PR DESCRIPTION
It's conceivable that the duplication could cause incorrect behavior since 3C currently matches structs and typedefs by source location (https://github.com/correctcomputation/checkedc-clang/issues/499).

@john-h-kastner After I approved #19, I thought I should take a closer look at what it was actually doing to the yacr2 code, and I discovered this problem.  I ran the sed scripts locally on yacr2 and the results looked like what I intended, but I haven't tried a build yet.  If you are OK with the approach, contingent on the workflow working as intended, then I'll try running the workflow.