### PR TITLE
icecast: Turn off _GNU_SOURCE to work around the sockaddr transparent union problem.

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -3377,6 +3377,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3419,6 +3420,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes_only_g_sol
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3462,6 +3464,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes_only_l_sol
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3505,6 +3508,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3548,6 +3552,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3591,6 +3596,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes_only_g_sol
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3635,6 +3641,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes_only_l_sol
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -3679,6 +3686,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1217,6 +1217,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -1246,6 +1247,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -1276,6 +1278,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 
@@ -1306,6 +1309,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
+          sed -i '/_GNU_SOURCE/d' configure
           CC="${{env.builddir}}/bin/clang" ./configure
           bear make -j $(nproc) -l $(nproc) --output-sync
 

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -207,7 +207,13 @@ benchmarks = [
         name='icecast',
         friendly_name='Icecast',
         dir_name='icecast-2.4.4',
+        # Turn off _GNU_SOURCE to work around the problem with transparent
+        # unions for `struct sockaddr *`
+        # (https://github.com/microsoft/checkedc/issues/441). `configure` was
+        # generated from `configure.in` by autoconf, but we don't want to re-run
+        # autoconf here, so just patch the generated file. :/
         build_cmds=textwrap.dedent(f'''\
+        sed -i '/_GNU_SOURCE/d' configure
         CC="${{{{env.builddir}}}}/bin/clang" ./configure
         bear {make_std}
         '''),


### PR DESCRIPTION
(https://github.com/microsoft/checkedc/issues/441)

[Workflow run](https://github.com/correctcomputation/actions/runs/2255575178?check_suite_focus=true): "Build Icecast" is successful again.