### PR TITLE
Stop ignoring failure of -alltypes post-conversion build steps.

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -183,12 +183,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_no_expand_macros_alltypes_only_l_sol:
     name: Test Vsftpd (not macro-expanded, -alltypes, least solution)
@@ -226,12 +226,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_no_expand_macros_alltypes:
     name: Test Vsftpd (not macro-expanded, -alltypes)
@@ -268,12 +268,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_expand_macros_no_alltypes:
     name: Test Vsftpd (macro-expanded, no -alltypes)
@@ -354,12 +354,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_expand_macros_alltypes_only_l_sol:
     name: Test Vsftpd (macro-expanded, -alltypes, least solution)
@@ -398,12 +398,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_expand_macros_alltypes:
     name: Test Vsftpd (macro-expanded, -alltypes)
@@ -441,12 +441,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_ptrdist_no_expand_macros_no_alltypes:
     name: Test PtrDist (not macro-expanded, no -alltypes)
@@ -659,12 +659,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -689,12 +689,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -719,12 +719,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -749,12 +749,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -779,12 +779,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_no_expand_macros_alltypes_only_l_sol:
     name: Test PtrDist (not macro-expanded, -alltypes, least solution)
@@ -833,12 +833,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -863,12 +863,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -893,12 +893,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -923,12 +923,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -953,12 +953,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_no_expand_macros_alltypes:
     name: Test PtrDist (not macro-expanded, -alltypes)
@@ -1006,12 +1006,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -1035,12 +1035,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -1064,12 +1064,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -1093,12 +1093,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -1122,12 +1122,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_expand_macros_no_alltypes:
     name: Test PtrDist (macro-expanded, no -alltypes)
@@ -1346,12 +1346,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -1377,12 +1377,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -1408,12 +1408,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -1439,12 +1439,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -1470,12 +1470,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_expand_macros_alltypes_only_l_sol:
     name: Test PtrDist (macro-expanded, -alltypes, least solution)
@@ -1525,12 +1525,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -1556,12 +1556,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -1587,12 +1587,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -1618,12 +1618,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -1649,12 +1649,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_expand_macros_alltypes:
     name: Test PtrDist (macro-expanded, -alltypes)
@@ -1703,12 +1703,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -1733,12 +1733,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -1763,12 +1763,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -1793,12 +1793,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -1823,12 +1823,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_libarchive_no_expand_macros_no_alltypes:
     name: Test LibArchive (not macro-expanded, no -alltypes)
@@ -1916,13 +1916,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_no_expand_macros_alltypes_only_l_sol:
     name: Test LibArchive (not macro-expanded, -alltypes, least solution)
@@ -1964,13 +1964,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_no_expand_macros_alltypes:
     name: Test LibArchive (not macro-expanded, -alltypes)
@@ -2011,13 +2011,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_expand_macros_no_alltypes:
     name: Test LibArchive (macro-expanded, no -alltypes)
@@ -2107,13 +2107,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_expand_macros_alltypes_only_l_sol:
     name: Test LibArchive (macro-expanded, -alltypes, least solution)
@@ -2156,13 +2156,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_expand_macros_alltypes:
     name: Test LibArchive (macro-expanded, -alltypes)
@@ -2204,13 +2204,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_lua_no_expand_macros_no_alltypes:
     name: Test Lua (not macro-expanded, no -alltypes)
@@ -2300,13 +2300,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_no_expand_macros_alltypes_only_l_sol:
     name: Test Lua (not macro-expanded, -alltypes, least solution)
@@ -2349,13 +2349,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_no_expand_macros_alltypes:
     name: Test Lua (not macro-expanded, -alltypes)
@@ -2397,13 +2397,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_expand_macros_no_alltypes:
     name: Test Lua (macro-expanded, no -alltypes)
@@ -2495,13 +2495,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_expand_macros_alltypes_only_l_sol:
     name: Test Lua (macro-expanded, -alltypes, least solution)
@@ -2545,13 +2545,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_expand_macros_alltypes:
     name: Test Lua (macro-expanded, -alltypes)
@@ -2594,13 +2594,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_libtiff_no_expand_macros_no_alltypes:
     name: Test LibTiff (not macro-expanded, no -alltypes)
@@ -2699,12 +2699,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_no_expand_macros_alltypes_only_l_sol:
     name: Test LibTiff (not macro-expanded, -alltypes, least solution)
@@ -2752,12 +2752,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_no_expand_macros_alltypes:
     name: Test LibTiff (not macro-expanded, -alltypes)
@@ -2804,12 +2804,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_expand_macros_no_alltypes:
     name: Test LibTiff (macro-expanded, no -alltypes)
@@ -2910,12 +2910,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_expand_macros_alltypes_only_l_sol:
     name: Test LibTiff (macro-expanded, -alltypes, least solution)
@@ -2964,12 +2964,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_expand_macros_alltypes:
     name: Test LibTiff (macro-expanded, -alltypes)
@@ -3017,12 +3017,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_zlib_no_expand_macros_no_alltypes:
     name: Test ZLib (not macro-expanded, no -alltypes)
@@ -3112,13 +3112,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_no_expand_macros_alltypes_only_l_sol:
     name: Test ZLib (not macro-expanded, -alltypes, least solution)
@@ -3161,13 +3161,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_no_expand_macros_alltypes:
     name: Test ZLib (not macro-expanded, -alltypes)
@@ -3209,13 +3209,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_expand_macros_no_alltypes:
     name: Test ZLib (macro-expanded, no -alltypes)
@@ -3307,13 +3307,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_expand_macros_alltypes_only_l_sol:
     name: Test ZLib (macro-expanded, -alltypes, least solution)
@@ -3357,13 +3357,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_expand_macros_alltypes:
     name: Test ZLib (macro-expanded, -alltypes)
@@ -3406,13 +3406,13 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_icecast_no_expand_macros_no_alltypes:
     name: Test Icecast (not macro-expanded, no -alltypes)
@@ -3495,12 +3495,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_no_expand_macros_alltypes_only_l_sol:
     name: Test Icecast (not macro-expanded, -alltypes, least solution)
@@ -3540,12 +3540,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_no_expand_macros_alltypes:
     name: Test Icecast (not macro-expanded, -alltypes)
@@ -3584,12 +3584,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_expand_macros_no_alltypes:
     name: Test Icecast (macro-expanded, no -alltypes)
@@ -3674,12 +3674,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_expand_macros_alltypes_only_l_sol:
     name: Test Icecast (macro-expanded, -alltypes, least solution)
@@ -3720,12 +3720,12 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_expand_macros_alltypes:
     name: Test Icecast (macro-expanded, -alltypes)
@@ -3765,9 +3765,9 @@ jobs:
           path: ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4/3c_performance_stats/
           retention-days: 5
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,12 +156,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_vsftpd_expand_macros_no_alltypes:
     name: Test Vsftpd (macro-expanded, no -alltypes)
@@ -215,12 +215,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted Vsftpd (ignore failure)
+      - name: Build converted Vsftpd
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -Wno-enum-conversion" -k
 
   test_ptrdist_no_expand_macros_no_alltypes:
     name: Test PtrDist (not macro-expanded, no -alltypes)
@@ -354,12 +354,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -370,12 +370,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -386,12 +386,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -402,12 +402,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -418,12 +418,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_ptrdist_expand_macros_no_alltypes:
     name: Test PtrDist (macro-expanded, no -alltypes)
@@ -563,12 +563,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted anagram (ignore failure)
+      - name: Build converted anagram
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert bc
         run: |
@@ -580,12 +580,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted bc (ignore failure)
+      - name: Build converted bc
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ft
         run: |
@@ -597,12 +597,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted ft (ignore failure)
+      - name: Build converted ft
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert ks
         run: |
@@ -614,12 +614,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted ks (ignore failure)
+      - name: Build converted ks
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
       - name: Convert yacr2
         run: |
@@ -631,12 +631,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted yacr2 (ignore failure)
+      - name: Build converted yacr2
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE" || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -D_ISOC99_SOURCE"
 
   test_libarchive_no_expand_macros_no_alltypes:
     name: Test LibArchive (not macro-expanded, no -alltypes)
@@ -697,13 +697,13 @@ jobs:
             --project_path . \
             --build_dir build
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_libarchive_expand_macros_no_alltypes:
     name: Test LibArchive (macro-expanded, no -alltypes)
@@ -766,13 +766,13 @@ jobs:
             --project_path . \
             --build_dir build
 
-      - name: Build converted LibArchive (ignore failure)
+      - name: Build converted LibArchive
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 archive || true
+          ninja -l $(nproc) -k 0 archive
 
   test_lua_no_expand_macros_no_alltypes:
     name: Test Lua (not macro-expanded, no -alltypes)
@@ -835,13 +835,13 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_lua_expand_macros_no_alltypes:
     name: Test Lua (macro-expanded, no -alltypes)
@@ -906,13 +906,13 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted Lua (ignore failure)
+      - name: Build converted Lua
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           cp -r out.checked/* .
           rm -r out.checked
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux || true
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w" linux
 
   test_libtiff_no_expand_macros_no_alltypes:
     name: Test LibTiff (not macro-expanded, no -alltypes)
@@ -984,12 +984,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_libtiff_expand_macros_no_alltypes:
     name: Test LibTiff (macro-expanded, no -alltypes)
@@ -1063,12 +1063,12 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted LibTiff (ignore failure)
+      - name: Build converted LibTiff
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
           cp -r out.checked/* .
           rm -r out.checked
-          ninja -l $(nproc) -k 0 tiff || true
+          ninja -l $(nproc) -k 0 tiff
 
   test_zlib_no_expand_macros_no_alltypes:
     name: Test ZLib (not macro-expanded, no -alltypes)
@@ -1131,13 +1131,13 @@ jobs:
             --project_path . \
             --build_dir build
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_zlib_expand_macros_no_alltypes:
     name: Test ZLib (macro-expanded, no -alltypes)
@@ -1202,13 +1202,13 @@ jobs:
             --project_path . \
             --build_dir build
 
-      - name: Build converted ZLib (ignore failure)
+      - name: Build converted ZLib
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           cp -r out.checked/* .
           rm -r out.checked
           cd build
-          ninja -l $(nproc) -k 0 zlib || true
+          ninja -l $(nproc) -k 0 zlib
 
   test_icecast_no_expand_macros_no_alltypes:
     name: Test Icecast (not macro-expanded, no -alltypes)
@@ -1264,12 +1264,12 @@ jobs:
             --extra-3c-arg=-alltypes \
             --project_path .
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k
 
   test_icecast_expand_macros_no_alltypes:
     name: Test Icecast (macro-expanded, no -alltypes)
@@ -1327,9 +1327,9 @@ jobs:
             --expand_macros_before_conversion \
             --project_path .
 
-      - name: Build converted Icecast (ignore failure)
+      - name: Build converted Icecast
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k || true
+          make -j $(nproc) -l $(nproc) --output-sync -k

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -445,8 +445,6 @@ def generate_benchmark_job(out: TextIO,
     benchmark_convert_extra = (ensure_trailing_newline(binfo.convert_extra)
                                if binfo.convert_extra is not None else '')
     build_converted_cmd = binfo.build_converted_cmd.rstrip('\n')
-    at_ignore_step = ' (ignore failure)' if variant.alltypes else ''
-    at_ignore_code = ' || true' if variant.alltypes else ''
 
     # The blank line below is important: it gets us blank lines between jobs
     # without a blank line at the very end of the workflow file.
@@ -524,7 +522,7 @@ def generate_benchmark_job(out: TextIO,
 
         steps.append(
             RunStep(
-                'Build converted ' + component_friendly_name + at_ignore_step,
+                'Build converted ' + component_friendly_name,
                 # convert_project.py sets -output-dir=out.checked as
                 # standard.
                 textwrap.dedent(f'''\
@@ -535,7 +533,7 @@ def generate_benchmark_job(out: TextIO,
                 #
                 (f'cd {component.build_dir}\n'
                  if component.build_dir is not None else '') +
-                f'{build_converted_cmd}{at_ignore_code}\n'))
+                f'{build_converted_cmd}\n'))
 
     # We want blank lines between steps but not after the last step of
     # the last benchmark.


### PR DESCRIPTION
The only effect this currently has is to let the job status change from success to failure. I think that reflecting reality in this way is helpful (while working on another task, I had forgotten that the "success" status does not mean that the builds are successful) and the practical concerns that originally led us to ignore failure are no longer significant: (1) the workflow is far from passing as a whole
anyway and (2) 3C failures are now rare, so having the job status indicate 3C success or failure is less useful.

[Previous discussion](https://correct-computation.slack.com/archives/G01GKGKHMFD/p1617230716020300).

John: If you are OK with this change in principle, I'll run the workflow to test it.