### PR TITLE
thttpd: Turn off parallel build due to problem with match.o.

### DIFF
--- a/.github/workflows/exhaustive.yml
+++ b/.github/workflows/exhaustive.yml
@@ -5763,7 +5763,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -5791,7 +5791,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k
+          make -k
 
   test_thhtpd_no_expand_macros_alltypes_only_g_sol:
     name: Test Thhtpd (not macro-expanded, -alltypes, greatest solution)
@@ -5807,7 +5807,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -5837,7 +5837,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_no_expand_macros_alltypes_only_l_sol:
     name: Test Thhtpd (not macro-expanded, -alltypes, least solution)
@@ -5853,7 +5853,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -5883,7 +5883,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_no_expand_macros_alltypes_disable_rds:
     name: Test Thhtpd (not macro-expanded, -alltypes, CCured solution)
@@ -5899,7 +5899,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -5929,7 +5929,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Thhtpd (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -5945,7 +5945,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -5975,7 +5975,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_no_expand_macros_alltypes:
     name: Test Thhtpd (not macro-expanded, -alltypes)
@@ -5991,7 +5991,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6020,7 +6020,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_no_alltypes:
     name: Test Thhtpd (macro-expanded, no -alltypes)
@@ -6036,7 +6036,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6065,7 +6065,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k
+          make -k
 
   test_thhtpd_expand_macros_alltypes_only_g_sol:
     name: Test Thhtpd (macro-expanded, -alltypes, greatest solution)
@@ -6081,7 +6081,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6112,7 +6112,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_alltypes_only_l_sol:
     name: Test Thhtpd (macro-expanded, -alltypes, least solution)
@@ -6128,7 +6128,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6159,7 +6159,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_alltypes_disable_rds:
     name: Test Thhtpd (macro-expanded, -alltypes, CCured solution)
@@ -6175,7 +6175,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6206,7 +6206,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_alltypes_disable_fnedgs:
     name: Test Thhtpd (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -6222,7 +6222,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6253,7 +6253,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_alltypes:
     name: Test Thhtpd (macro-expanded, -alltypes)
@@ -6269,7 +6269,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -6299,4 +6299,4 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1387,7 +1387,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -1402,7 +1402,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k
+          make -k
 
   test_thhtpd_no_expand_macros_alltypes:
     name: Test Thhtpd (not macro-expanded, -alltypes)
@@ -1418,7 +1418,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -1434,7 +1434,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
 
   test_thhtpd_expand_macros_no_alltypes:
     name: Test Thhtpd (macro-expanded, no -alltypes)
@@ -1450,7 +1450,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -1466,7 +1466,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k
+          make -k
 
   test_thhtpd_expand_macros_alltypes:
     name: Test Thhtpd (macro-expanded, -alltypes)
@@ -1482,7 +1482,7 @@ jobs:
           cd thttpd-2.29
           CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" ./configure
           chmod -R 777 *
-          bear make -j $(nproc) -l $(nproc) --output-sync
+          bear make
 
       - name: Convert Thhtpd
         run: |
@@ -1499,4 +1499,4 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           cp -r out.checked/* .
           rm -r out.checked
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -253,18 +253,26 @@ benchmarks = [
         '''),
         build_converted_cmd=f'{make_std} -k'),
 
-    # thhtpd
+    # thttpd
     BenchmarkInfo(
         #
         name='thhtpd',
         friendly_name='Thhtpd',
         dir_name='thttpd-2.29',
+        # It's not safe to build thttpd in parallel: the main and cgi-src
+        # Makefiles may try to build match.o in parallel, which would result in
+        # a duplicate compilation database entry (which breaks the macro
+        # expander) or possibly other corruption. Another possible workaround
+        # might be to force match.o to be built first, but it seems more
+        # reasonable to just turn off parallelism (despite the modest running
+        # time cost) than to hard-code the knowledge of the specific problem
+        # here.
         build_cmds=textwrap.dedent(f'''\
         CC="${{{{env.builddir}}}}/bin/clang" CFLAGS="{common_cflags}" ./configure
         chmod -R 777 *
-        bear {make_std}
+        bear make
         '''),
-        build_converted_cmd=f'{make_std} -k',
+        build_converted_cmd=f'make -k',
         patch_dir='thttpd-2.29_patches'),
 ]
 


### PR DESCRIPTION
[Workflow run](https://github.com/correctcomputation/actions/actions/runs/749150894): the set of passing jobs looks reasonable compared to [this baseline run](https://github.com/correctcomputation/actions/actions/runs/747392331).

In combination with correctcomputation/checkedc-clang#548, this should fix macro expansion in thttpd.  Each PR should be backward compatible in isolation, but both are needed for the fix, and I'm only bothering to test the combination.