### PR TITLE
Stop passing the --includeDir option to convert_project.

### DIFF
--- a/.github/workflows/exhaustiveccured.yml
+++ b/.github/workflows/exhaustiveccured.yml
@@ -20,7 +20,6 @@ env:
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
-  include_dir: "${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc/include"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
 
 jobs:
@@ -126,7 +125,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -168,7 +166,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -210,7 +207,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -253,7 +249,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -296,7 +291,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -338,7 +332,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -380,7 +373,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -423,7 +415,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -469,7 +460,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -499,7 +489,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -529,7 +518,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -559,7 +547,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -589,7 +576,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -619,7 +605,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -649,7 +634,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -679,7 +663,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -709,7 +692,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -739,7 +721,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -792,7 +773,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -822,7 +802,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -852,7 +831,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -882,7 +860,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -912,7 +889,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -942,7 +918,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -972,7 +947,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -1002,7 +976,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -1032,7 +1005,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -1062,7 +1034,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -1115,7 +1086,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1146,7 +1116,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1177,7 +1146,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1208,7 +1176,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1239,7 +1206,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1270,7 +1236,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1301,7 +1266,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1332,7 +1296,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1363,7 +1326,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1394,7 +1356,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1448,7 +1409,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1479,7 +1439,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1510,7 +1469,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1541,7 +1499,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1572,7 +1529,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1603,7 +1559,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1634,7 +1589,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1665,7 +1619,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1696,7 +1649,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1727,7 +1679,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1789,7 +1740,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -1818,7 +1768,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -1847,7 +1796,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -1876,7 +1824,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -1905,7 +1852,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -1966,7 +1912,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -1995,7 +1940,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2024,7 +1968,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2053,7 +1996,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2082,7 +2024,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2143,7 +2084,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2173,7 +2113,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2203,7 +2142,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2233,7 +2171,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2263,7 +2200,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2325,7 +2261,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2355,7 +2290,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2385,7 +2319,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2415,7 +2348,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2445,7 +2377,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2499,7 +2430,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -2546,7 +2476,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2593,7 +2522,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2641,7 +2569,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2691,7 +2618,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -2739,7 +2665,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2787,7 +2712,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2836,7 +2760,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2891,7 +2814,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -2944,7 +2866,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -2997,7 +2918,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3051,7 +2971,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3098,7 +3017,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -3146,7 +3064,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -3194,7 +3111,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3243,7 +3159,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3290,7 +3205,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -3334,7 +3248,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -3378,7 +3291,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3423,7 +3335,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3469,7 +3380,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-rds \
@@ -3514,7 +3424,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-disable-fnedgs \
@@ -3559,7 +3468,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3605,7 +3513,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \

--- a/.github/workflows/exhaustiveleastgreatest.yml
+++ b/.github/workflows/exhaustiveleastgreatest.yml
@@ -20,7 +20,6 @@ env:
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
-  include_dir: "${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc/include"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
 
 jobs:
@@ -126,7 +125,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -168,7 +166,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -210,7 +207,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -253,7 +249,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -296,7 +291,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -338,7 +332,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -380,7 +373,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -423,7 +415,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -469,7 +460,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -499,7 +489,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -529,7 +518,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -559,7 +547,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -589,7 +576,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -619,7 +605,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -649,7 +634,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -679,7 +663,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -709,7 +692,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -739,7 +721,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -792,7 +773,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -822,7 +802,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -852,7 +831,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -882,7 +860,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -912,7 +889,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -942,7 +918,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -972,7 +947,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -1002,7 +976,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -1032,7 +1005,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -1062,7 +1034,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -1115,7 +1086,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1146,7 +1116,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1177,7 +1146,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1208,7 +1176,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1239,7 +1206,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1270,7 +1236,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1301,7 +1266,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1332,7 +1296,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1363,7 +1326,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1394,7 +1356,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1448,7 +1409,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1479,7 +1439,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1510,7 +1469,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1541,7 +1499,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1572,7 +1529,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1603,7 +1559,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1634,7 +1589,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1665,7 +1619,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1696,7 +1649,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1727,7 +1679,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1789,7 +1740,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -1818,7 +1768,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -1847,7 +1796,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -1876,7 +1824,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -1905,7 +1852,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -1966,7 +1912,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -1995,7 +1940,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2024,7 +1968,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2053,7 +1996,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2082,7 +2024,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2143,7 +2084,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2173,7 +2113,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2203,7 +2142,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2233,7 +2171,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2263,7 +2200,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2325,7 +2261,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2355,7 +2290,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2385,7 +2319,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2415,7 +2348,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2445,7 +2377,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2499,7 +2430,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -2546,7 +2476,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2593,7 +2522,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2641,7 +2569,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2691,7 +2618,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -2739,7 +2665,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2787,7 +2712,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2836,7 +2760,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2891,7 +2814,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -2944,7 +2866,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -2997,7 +2918,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3051,7 +2971,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3098,7 +3017,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -3146,7 +3064,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -3194,7 +3111,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3243,7 +3159,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3290,7 +3205,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -3334,7 +3248,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -3378,7 +3291,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3423,7 +3335,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3469,7 +3380,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-g-sol \
@@ -3514,7 +3424,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --extra-3c-arg=-only-l-sol \
@@ -3559,7 +3468,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3605,7 +3513,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \

--- a/.github/workflows/exhaustivestats.yml
+++ b/.github/workflows/exhaustivestats.yml
@@ -20,7 +20,6 @@ env:
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
-  include_dir: "${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc/include"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
 
 jobs:
@@ -126,7 +125,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -166,7 +164,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -207,7 +204,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -248,7 +244,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -290,7 +285,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -330,7 +324,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -371,7 +364,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -412,7 +404,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -457,7 +448,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -485,7 +475,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -513,7 +502,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -541,7 +529,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -569,7 +556,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -597,7 +583,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -625,7 +610,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -653,7 +637,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -681,7 +664,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -709,7 +691,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -760,7 +741,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -789,7 +769,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -818,7 +797,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -847,7 +825,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -876,7 +853,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -905,7 +881,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -934,7 +909,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -963,7 +937,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -992,7 +965,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1021,7 +993,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1073,7 +1044,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1102,7 +1072,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1131,7 +1100,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1160,7 +1128,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1189,7 +1156,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1218,7 +1184,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1247,7 +1212,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1276,7 +1240,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1305,7 +1268,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1334,7 +1296,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1386,7 +1347,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1416,7 +1376,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1446,7 +1405,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1476,7 +1434,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1506,7 +1463,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1536,7 +1492,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1566,7 +1521,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1596,7 +1550,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1626,7 +1579,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1656,7 +1608,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1717,7 +1668,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1744,7 +1694,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1771,7 +1720,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1798,7 +1746,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1825,7 +1772,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1884,7 +1830,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1912,7 +1857,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1940,7 +1884,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1968,7 +1911,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1996,7 +1938,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -2056,7 +1997,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2084,7 +2024,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2112,7 +2051,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2140,7 +2078,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2168,7 +2105,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2228,7 +2164,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2257,7 +2192,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2286,7 +2220,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2315,7 +2248,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2344,7 +2276,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2397,7 +2328,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
             --build_dir build
@@ -2442,7 +2372,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path . \
@@ -2488,7 +2417,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path . \
@@ -2534,7 +2462,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2583,7 +2510,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -2629,7 +2555,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -2676,7 +2601,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2723,7 +2647,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2777,7 +2700,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -2828,7 +2750,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -2880,7 +2801,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2932,7 +2852,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2978,7 +2897,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
             --build_dir build
@@ -3024,7 +2942,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path . \
@@ -3071,7 +2988,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path . \
@@ -3118,7 +3034,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3164,7 +3079,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -3206,7 +3120,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -3249,7 +3162,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -3292,7 +3204,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -3337,7 +3248,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -3380,7 +3290,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -3424,7 +3333,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -3468,7 +3376,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ env:
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
-  include_dir: "${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc/include"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
 
 jobs:
@@ -126,7 +125,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -153,7 +151,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -181,7 +178,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -209,7 +205,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -238,7 +233,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -265,7 +259,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -293,7 +286,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -321,7 +313,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/parson
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -353,7 +344,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -368,7 +358,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -383,7 +372,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -398,7 +386,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -413,7 +400,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -428,7 +414,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -443,7 +428,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -458,7 +442,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -473,7 +456,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -488,7 +470,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -526,7 +507,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -542,7 +522,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -558,7 +537,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -574,7 +552,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -590,7 +567,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -606,7 +582,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -622,7 +597,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -638,7 +612,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -654,7 +627,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -670,7 +642,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -709,7 +680,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -725,7 +695,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -741,7 +710,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -757,7 +725,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -773,7 +740,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -789,7 +755,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -805,7 +770,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -821,7 +785,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -837,7 +800,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -853,7 +815,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -892,7 +853,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bh
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -909,7 +869,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bisort
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -926,7 +885,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/em3d
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -943,7 +901,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/health
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -960,7 +917,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/mst
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -977,7 +933,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/perimeter
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -994,7 +949,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/power
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1011,7 +965,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/treeadd
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1028,7 +981,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/tsp
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1045,7 +997,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/voronoi
           ${{env.port_tools}}/convert_project.py \
             --extra-3c-arg=-allow-unwritable-changes \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1093,7 +1044,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1107,7 +1057,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1121,7 +1070,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1135,7 +1083,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1149,7 +1096,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1195,7 +1141,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1210,7 +1155,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1225,7 +1169,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1240,7 +1183,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1255,7 +1197,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1302,7 +1243,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1317,7 +1257,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1332,7 +1271,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1347,7 +1285,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1362,7 +1299,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1409,7 +1345,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1425,7 +1360,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1441,7 +1375,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1457,7 +1390,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1473,7 +1405,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1513,7 +1444,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
             --build_dir build
@@ -1545,7 +1475,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path . \
@@ -1578,7 +1507,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path . \
@@ -1611,7 +1539,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/(test|test_utils|tar|cat|cpio|examples|contrib|libarchive_fe)/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1647,7 +1574,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1680,7 +1606,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1714,7 +1639,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1748,7 +1672,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1789,7 +1712,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -1827,7 +1749,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -1866,7 +1787,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -1905,7 +1825,6 @@ jobs:
             --skip '/.*/tif_stream.cxx' \
             --skip '.*/test/.*\.c' \
             --skip '.*/contrib/.*\.c' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -1938,7 +1857,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path . \
             --build_dir build
@@ -1971,7 +1889,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path . \
@@ -2005,7 +1922,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path . \
@@ -2039,7 +1955,6 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           ${{env.port_tools}}/convert_project.py \
             --skip '/.*/test/.*' \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2072,7 +1987,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -2101,7 +2015,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -2131,7 +2044,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2161,7 +2073,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \
@@ -2193,7 +2104,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --project_path .
 
@@ -2223,7 +2133,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --project_path .
@@ -2254,7 +2163,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --expand_macros_before_conversion \
             --project_path .
@@ -2285,7 +2193,6 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           ${{env.port_tools}}/convert_project.py \
-            --includeDir ${{env.include_dir}} \
             --prog_name ${{env.builddir}}/bin/3c \
             --extra-3c-arg=-alltypes \
             --expand_macros_before_conversion \

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -357,7 +357,6 @@ env:
   builddir: "${{github.workspace}}/b/ninja"
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
-  include_dir: "${{github.workspace}}/depsfolder/checkedc-clang/llvm/projects/checkedc-wrapper/checkedc/include"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
 
 jobs:
@@ -592,7 +591,6 @@ def generate_benchmark_job(out: TextIO,
         # yapf: disable
         convert_flags = textwrap.indent(
             benchmark_convert_extra +
-            '--includeDir ${{env.include_dir}} \\\n' +
             '--prog_name ${{env.builddir}}/bin/3c \\\n' +
             subvariant_convert_extra +
             '--project_path .' +


### PR DESCRIPTION
It already isn't being used because include updating is off by default in convert_project, and it will cause an error once the --includeDir option is removed from convert_project in correctcomputation/checkedc-clang#574.

[Workflow run](https://github.com/correctcomputation/actions/actions/runs/828764435): the same jobs pass as [the baseline](https://github.com/correctcomputation/actions/actions/runs/826879063), except for a regression test that looks like a random failure: I logged in to the GitHub runner and re-ran `ninja check-3c` and the test passed.  (Random failures don't give me a good feeling, but I don't know what else we can do about them right now.)