### PR TITLE
Disabling automatically running stats workflows

### DIFF
--- a/.github/workflows/exhaustiveccured.yml
+++ b/.github/workflows/exhaustiveccured.yml
@@ -5,8 +5,6 @@
 name: Exhaustive testing and Performance Stats (CCured)
 
 on:
-  # Run every day at the following time.
-  
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/exhaustiveleastgreatest.yml
+++ b/.github/workflows/exhaustiveleastgreatest.yml
@@ -5,8 +5,6 @@
 name: Exhaustive testing and Performance Stats (Least and Greatest)
 
 on:
-  # Run every day at the following time.
-  
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/exhaustivestats.yml
+++ b/.github/workflows/exhaustivestats.yml
@@ -5,8 +5,6 @@
 name: Exhaustive testing and Performance Stats
 
 on:
-  # Run every day at the following time.
-  
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
We do not need to run the stats computing workflows every night. This will necessarily consume storage space on github.