### PR TITLE
Add support for generating scripts to run benchmarks locally.

### DIFF
--- a/.github/workflows/exhaustiveccured.yml
+++ b/.github/workflows/exhaustiveccured.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -176,7 +176,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -219,7 +219,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -262,7 +262,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -304,7 +304,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -346,7 +346,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -389,7 +389,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -432,7 +432,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -477,7 +477,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -506,7 +506,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -535,7 +535,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -564,7 +564,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -593,7 +593,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -622,7 +622,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -651,7 +651,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -680,7 +680,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -709,7 +709,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -738,7 +738,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -791,7 +791,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -820,7 +820,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -849,7 +849,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -878,7 +878,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -907,7 +907,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -936,7 +936,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -965,7 +965,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -994,7 +994,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1023,7 +1023,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1052,7 +1052,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1106,7 +1106,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1136,7 +1136,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1166,7 +1166,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1196,7 +1196,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1226,7 +1226,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1256,7 +1256,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1286,7 +1286,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1316,7 +1316,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1346,7 +1346,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1376,7 +1376,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1430,7 +1430,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1460,7 +1460,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1490,7 +1490,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1520,7 +1520,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1550,7 +1550,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1580,7 +1580,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1610,7 +1610,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1640,7 +1640,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1670,7 +1670,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1700,7 +1700,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1764,7 +1764,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1792,7 +1792,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1820,7 +1820,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -1848,7 +1848,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -1876,7 +1876,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -1940,7 +1940,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1968,7 +1968,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1996,7 +1996,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2024,7 +2024,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2052,7 +2052,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2117,7 +2117,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2146,7 +2146,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2175,7 +2175,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2204,7 +2204,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2233,7 +2233,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2298,7 +2298,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2327,7 +2327,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2356,7 +2356,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2385,7 +2385,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2414,7 +2414,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2468,7 +2468,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2515,7 +2515,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2563,7 +2563,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2611,7 +2611,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2659,7 +2659,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2707,7 +2707,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2756,7 +2756,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2805,7 +2805,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2859,7 +2859,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2912,7 +2912,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2966,7 +2966,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -3020,7 +3020,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -3067,7 +3067,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3115,7 +3115,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3164,7 +3164,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3213,7 +3213,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3258,7 +3258,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3302,7 +3302,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3347,7 +3347,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3392,7 +3392,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3437,7 +3437,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3482,7 +3482,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3528,7 +3528,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3574,7 +3574,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2

--- a/.github/workflows/exhaustiveccured.yml
+++ b/.github/workflows/exhaustiveccured.yml
@@ -19,6 +19,7 @@ env:
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
   clang_rename: "clang-rename-10"
+  actions_repo: "${{github.workspace}}/depsfolder/actions"
 
 jobs:
 
@@ -115,6 +116,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -145,7 +147,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Vsftpd (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -156,6 +158,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -186,7 +189,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_alltypes_disable_rds:
     name: Test Vsftpd (macro-expanded, -alltypes, CCured solution)
@@ -197,6 +200,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -228,7 +232,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_alltypes_disable_fnedgs:
     name: Test Vsftpd (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -239,6 +243,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -270,7 +275,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_alltypes_disable_rds:
     name: Test Parson (not macro-expanded, -alltypes, CCured solution)
@@ -281,6 +286,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -311,7 +317,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Parson (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -322,6 +328,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -352,7 +359,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_alltypes_disable_rds:
     name: Test Parson (macro-expanded, -alltypes, CCured solution)
@@ -363,6 +370,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -394,7 +402,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_alltypes_disable_fnedgs:
     name: Test Parson (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -405,6 +413,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -436,7 +445,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Olden_no_expand_macros_alltypes_disable_rds:
     name: Test Olden (not macro-expanded, -alltypes, CCured solution)
@@ -447,6 +456,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -480,7 +490,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -509,7 +519,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -538,7 +548,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -567,7 +577,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -596,7 +606,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -625,7 +635,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -654,7 +664,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -683,7 +693,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -712,7 +722,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -741,7 +751,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -760,6 +770,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -793,7 +804,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -822,7 +833,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -851,7 +862,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -880,7 +891,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -909,7 +920,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -938,7 +949,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -967,7 +978,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -996,7 +1007,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1025,7 +1036,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1054,7 +1065,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1073,6 +1084,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1107,7 +1119,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -1137,7 +1149,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -1167,7 +1179,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -1197,7 +1209,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -1227,7 +1239,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -1257,7 +1269,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -1287,7 +1299,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -1317,7 +1329,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1347,7 +1359,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1377,7 +1389,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1396,6 +1408,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1430,7 +1443,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -1460,7 +1473,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -1490,7 +1503,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -1520,7 +1533,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -1550,7 +1563,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -1580,7 +1593,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -1610,7 +1623,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -1640,7 +1653,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1670,7 +1683,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1700,7 +1713,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1719,6 +1732,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1763,7 +1777,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1791,7 +1805,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1819,7 +1833,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -1847,7 +1861,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -1875,7 +1889,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1894,6 +1908,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1938,7 +1953,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1966,7 +1981,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1994,7 +2009,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2022,7 +2037,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2050,7 +2065,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2069,6 +2084,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2114,7 +2130,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -2143,7 +2159,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -2172,7 +2188,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2201,7 +2217,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2230,7 +2246,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2249,6 +2265,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2294,7 +2311,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -2323,7 +2340,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -2352,7 +2369,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2381,7 +2398,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2410,7 +2427,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2429,6 +2446,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2464,7 +2482,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_no_expand_macros_alltypes_disable_fnedgs:
     name: Test LibArchive (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2475,6 +2493,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2510,7 +2529,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_alltypes_disable_rds:
     name: Test LibArchive (macro-expanded, -alltypes, CCured solution)
@@ -2521,6 +2540,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2557,7 +2577,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_alltypes_disable_fnedgs:
     name: Test LibArchive (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2568,6 +2588,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2604,7 +2625,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_alltypes_disable_rds:
     name: Test Lua (not macro-expanded, -alltypes, CCured solution)
@@ -2615,6 +2636,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2651,7 +2673,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Lua (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2662,6 +2684,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2698,7 +2721,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_alltypes_disable_rds:
     name: Test Lua (macro-expanded, -alltypes, CCured solution)
@@ -2709,6 +2732,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2746,7 +2770,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_alltypes_disable_fnedgs:
     name: Test Lua (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2757,6 +2781,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2794,7 +2819,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_alltypes_disable_rds:
     name: Test LibTiff (not macro-expanded, -alltypes, CCured solution)
@@ -2805,6 +2830,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2846,7 +2872,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_alltypes_disable_fnedgs:
     name: Test LibTiff (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2857,6 +2883,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2898,7 +2925,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_alltypes_disable_rds:
     name: Test LibTiff (macro-expanded, -alltypes, CCured solution)
@@ -2909,6 +2936,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2951,7 +2979,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_alltypes_disable_fnedgs:
     name: Test LibTiff (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -2962,6 +2990,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -3004,7 +3033,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_alltypes_disable_rds:
     name: Test ZLib (not macro-expanded, -alltypes, CCured solution)
@@ -3015,6 +3044,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3051,7 +3081,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_alltypes_disable_fnedgs:
     name: Test ZLib (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3062,6 +3092,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3098,7 +3129,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_alltypes_disable_rds:
     name: Test ZLib (macro-expanded, -alltypes, CCured solution)
@@ -3109,6 +3140,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3146,7 +3178,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_alltypes_disable_fnedgs:
     name: Test ZLib (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3157,6 +3189,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3194,7 +3227,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_alltypes_disable_rds:
     name: Test Icecast (not macro-expanded, -alltypes, CCured solution)
@@ -3205,6 +3238,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3237,7 +3271,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Icecast (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3248,6 +3282,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3280,7 +3315,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_alltypes_disable_rds:
     name: Test Icecast (macro-expanded, -alltypes, CCured solution)
@@ -3291,6 +3326,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3324,7 +3360,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_alltypes_disable_fnedgs:
     name: Test Icecast (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3335,6 +3371,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3368,7 +3405,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_alltypes_disable_rds:
     name: Test Thttpd (not macro-expanded, -alltypes, CCured solution)
@@ -3379,6 +3416,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3412,7 +3450,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_rds/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_alltypes_disable_fnedgs:
     name: Test Thttpd (not macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3423,6 +3461,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3456,7 +3495,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_alltypes_disable_rds:
     name: Test Thttpd (macro-expanded, -alltypes, CCured solution)
@@ -3467,6 +3506,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3501,7 +3541,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_rds/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_alltypes_disable_fnedgs:
     name: Test Thttpd (macro-expanded, -alltypes, FuncRevEdges solution)
@@ -3512,6 +3552,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3546,4 +3587,4 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_disable_fnedgs/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py

--- a/.github/workflows/exhaustiveccured.yml
+++ b/.github/workflows/exhaustiveccured.yml
@@ -18,6 +18,7 @@ env:
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
+  clang_rename: "clang-rename-10"
 
 jobs:
 
@@ -2618,7 +2619,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2665,7 +2666,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2712,7 +2713,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2760,7 +2761,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2811,7 +2812,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2863,7 +2864,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2915,7 +2916,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2968,7 +2969,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)

--- a/.github/workflows/exhaustiveleastgreatest.yml
+++ b/.github/workflows/exhaustiveleastgreatest.yml
@@ -19,6 +19,7 @@ env:
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
   clang_rename: "clang-rename-10"
+  actions_repo: "${{github.workspace}}/depsfolder/actions"
 
 jobs:
 
@@ -115,6 +116,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -145,7 +147,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_no_expand_macros_alltypes_only_l_sol:
     name: Test Vsftpd (not macro-expanded, -alltypes, least solution)
@@ -156,6 +158,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -186,7 +189,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_alltypes_only_g_sol:
     name: Test Vsftpd (macro-expanded, -alltypes, greatest solution)
@@ -197,6 +200,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -228,7 +232,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_alltypes_only_l_sol:
     name: Test Vsftpd (macro-expanded, -alltypes, least solution)
@@ -239,6 +243,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -270,7 +275,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_alltypes_only_g_sol:
     name: Test Parson (not macro-expanded, -alltypes, greatest solution)
@@ -281,6 +286,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -311,7 +317,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_alltypes_only_l_sol:
     name: Test Parson (not macro-expanded, -alltypes, least solution)
@@ -322,6 +328,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -352,7 +359,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_alltypes_only_g_sol:
     name: Test Parson (macro-expanded, -alltypes, greatest solution)
@@ -363,6 +370,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -394,7 +402,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_alltypes_only_l_sol:
     name: Test Parson (macro-expanded, -alltypes, least solution)
@@ -405,6 +413,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -436,7 +445,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Olden_no_expand_macros_alltypes_only_g_sol:
     name: Test Olden (not macro-expanded, -alltypes, greatest solution)
@@ -447,6 +456,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -480,7 +490,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -509,7 +519,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -538,7 +548,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -567,7 +577,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -596,7 +606,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -625,7 +635,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -654,7 +664,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -683,7 +693,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -712,7 +722,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -741,7 +751,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -760,6 +770,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -793,7 +804,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -822,7 +833,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -851,7 +862,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -880,7 +891,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -909,7 +920,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -938,7 +949,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -967,7 +978,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -996,7 +1007,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1025,7 +1036,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1054,7 +1065,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1073,6 +1084,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1107,7 +1119,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -1137,7 +1149,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -1167,7 +1179,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -1197,7 +1209,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -1227,7 +1239,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -1257,7 +1269,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -1287,7 +1299,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -1317,7 +1329,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1347,7 +1359,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1377,7 +1389,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1396,6 +1408,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1430,7 +1443,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -1460,7 +1473,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -1490,7 +1503,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -1520,7 +1533,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -1550,7 +1563,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -1580,7 +1593,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -1610,7 +1623,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -1640,7 +1653,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1670,7 +1683,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1700,7 +1713,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1719,6 +1732,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1763,7 +1777,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1791,7 +1805,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1819,7 +1833,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -1847,7 +1861,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -1875,7 +1889,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1894,6 +1908,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1938,7 +1953,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1966,7 +1981,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1994,7 +2009,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2022,7 +2037,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2050,7 +2065,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2069,6 +2084,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2114,7 +2130,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -2143,7 +2159,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -2172,7 +2188,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2201,7 +2217,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2230,7 +2246,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2249,6 +2265,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2294,7 +2311,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -2323,7 +2340,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -2352,7 +2369,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2381,7 +2398,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2410,7 +2427,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2429,6 +2446,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2464,7 +2482,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_no_expand_macros_alltypes_only_l_sol:
     name: Test LibArchive (not macro-expanded, -alltypes, least solution)
@@ -2475,6 +2493,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2510,7 +2529,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_alltypes_only_g_sol:
     name: Test LibArchive (macro-expanded, -alltypes, greatest solution)
@@ -2521,6 +2540,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2557,7 +2577,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_alltypes_only_l_sol:
     name: Test LibArchive (macro-expanded, -alltypes, least solution)
@@ -2568,6 +2588,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2604,7 +2625,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_alltypes_only_g_sol:
     name: Test Lua (not macro-expanded, -alltypes, greatest solution)
@@ -2615,6 +2636,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2651,7 +2673,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_alltypes_only_l_sol:
     name: Test Lua (not macro-expanded, -alltypes, least solution)
@@ -2662,6 +2684,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2698,7 +2721,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_alltypes_only_g_sol:
     name: Test Lua (macro-expanded, -alltypes, greatest solution)
@@ -2709,6 +2732,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2746,7 +2770,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_alltypes_only_l_sol:
     name: Test Lua (macro-expanded, -alltypes, least solution)
@@ -2757,6 +2781,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2794,7 +2819,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_alltypes_only_g_sol:
     name: Test LibTiff (not macro-expanded, -alltypes, greatest solution)
@@ -2805,6 +2830,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2846,7 +2872,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_alltypes_only_l_sol:
     name: Test LibTiff (not macro-expanded, -alltypes, least solution)
@@ -2857,6 +2883,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2898,7 +2925,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_alltypes_only_g_sol:
     name: Test LibTiff (macro-expanded, -alltypes, greatest solution)
@@ -2909,6 +2936,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2951,7 +2979,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_alltypes_only_l_sol:
     name: Test LibTiff (macro-expanded, -alltypes, least solution)
@@ -2962,6 +2990,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -3004,7 +3033,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_alltypes_only_g_sol:
     name: Test ZLib (not macro-expanded, -alltypes, greatest solution)
@@ -3015,6 +3044,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3051,7 +3081,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_alltypes_only_l_sol:
     name: Test ZLib (not macro-expanded, -alltypes, least solution)
@@ -3062,6 +3092,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3098,7 +3129,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_alltypes_only_g_sol:
     name: Test ZLib (macro-expanded, -alltypes, greatest solution)
@@ -3109,6 +3140,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3146,7 +3178,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_alltypes_only_l_sol:
     name: Test ZLib (macro-expanded, -alltypes, least solution)
@@ -3157,6 +3189,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3194,7 +3227,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_alltypes_only_g_sol:
     name: Test Icecast (not macro-expanded, -alltypes, greatest solution)
@@ -3205,6 +3238,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3237,7 +3271,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_alltypes_only_l_sol:
     name: Test Icecast (not macro-expanded, -alltypes, least solution)
@@ -3248,6 +3282,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3280,7 +3315,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_alltypes_only_g_sol:
     name: Test Icecast (macro-expanded, -alltypes, greatest solution)
@@ -3291,6 +3326,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3324,7 +3360,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_alltypes_only_l_sol:
     name: Test Icecast (macro-expanded, -alltypes, least solution)
@@ -3335,6 +3371,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3368,7 +3405,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_alltypes_only_g_sol:
     name: Test Thttpd (not macro-expanded, -alltypes, greatest solution)
@@ -3379,6 +3416,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3412,7 +3450,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_alltypes_only_l_sol:
     name: Test Thttpd (not macro-expanded, -alltypes, least solution)
@@ -3423,6 +3461,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3456,7 +3495,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_alltypes_only_g_sol:
     name: Test Thttpd (macro-expanded, -alltypes, greatest solution)
@@ -3467,6 +3506,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3501,7 +3541,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_alltypes_only_l_sol:
     name: Test Thttpd (macro-expanded, -alltypes, least solution)
@@ -3512,6 +3552,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3546,4 +3587,4 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py

--- a/.github/workflows/exhaustiveleastgreatest.yml
+++ b/.github/workflows/exhaustiveleastgreatest.yml
@@ -134,7 +134,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -176,7 +176,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -219,7 +219,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -262,7 +262,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -304,7 +304,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -346,7 +346,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -389,7 +389,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -432,7 +432,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -477,7 +477,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -506,7 +506,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -535,7 +535,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -564,7 +564,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -593,7 +593,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -622,7 +622,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -651,7 +651,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -680,7 +680,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -709,7 +709,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -738,7 +738,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -791,7 +791,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -820,7 +820,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -849,7 +849,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -878,7 +878,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -907,7 +907,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -936,7 +936,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -965,7 +965,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -994,7 +994,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1023,7 +1023,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1052,7 +1052,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1106,7 +1106,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1136,7 +1136,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1166,7 +1166,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1196,7 +1196,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1226,7 +1226,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1256,7 +1256,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1286,7 +1286,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1316,7 +1316,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1346,7 +1346,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1376,7 +1376,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1430,7 +1430,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1460,7 +1460,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1490,7 +1490,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1520,7 +1520,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1550,7 +1550,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1580,7 +1580,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1610,7 +1610,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1640,7 +1640,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1670,7 +1670,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1700,7 +1700,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1764,7 +1764,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1792,7 +1792,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1820,7 +1820,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -1848,7 +1848,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -1876,7 +1876,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -1940,7 +1940,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1968,7 +1968,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1996,7 +1996,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2024,7 +2024,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2052,7 +2052,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2117,7 +2117,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2146,7 +2146,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2175,7 +2175,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2204,7 +2204,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2233,7 +2233,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2298,7 +2298,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2327,7 +2327,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2356,7 +2356,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2385,7 +2385,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2414,7 +2414,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2468,7 +2468,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2515,7 +2515,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2563,7 +2563,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2611,7 +2611,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2659,7 +2659,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2707,7 +2707,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2756,7 +2756,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2805,7 +2805,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2859,7 +2859,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2912,7 +2912,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2966,7 +2966,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -3020,7 +3020,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -3067,7 +3067,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3115,7 +3115,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3164,7 +3164,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3213,7 +3213,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3258,7 +3258,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3302,7 +3302,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3347,7 +3347,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3392,7 +3392,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3437,7 +3437,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_g_sol/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3482,7 +3482,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes_only_l_sol/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3528,7 +3528,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_g_sol/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3574,7 +3574,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes_only_l_sol/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2

--- a/.github/workflows/exhaustiveleastgreatest.yml
+++ b/.github/workflows/exhaustiveleastgreatest.yml
@@ -18,6 +18,7 @@ env:
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
+  clang_rename: "clang-rename-10"
 
 jobs:
 
@@ -2618,7 +2619,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2665,7 +2666,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2712,7 +2713,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2760,7 +2761,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2811,7 +2812,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2863,7 +2864,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2915,7 +2916,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2968,7 +2969,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)

--- a/.github/workflows/exhaustivestats.yml
+++ b/.github/workflows/exhaustivestats.yml
@@ -18,6 +18,7 @@ env:
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
+  clang_rename: "clang-rename-10"
 
 jobs:
 
@@ -2510,7 +2511,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2555,7 +2556,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2601,7 +2602,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2647,7 +2648,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -2697,7 +2698,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2747,7 +2748,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2798,7 +2799,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -2849,7 +2850,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)

--- a/.github/workflows/exhaustivestats.yml
+++ b/.github/workflows/exhaustivestats.yml
@@ -132,7 +132,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -173,7 +173,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -214,7 +214,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -256,7 +256,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Vsftpd
         uses: actions/upload-artifact@v2
@@ -296,7 +296,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -337,7 +337,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -378,7 +378,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -420,7 +420,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/parson
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Parson
         uses: actions/upload-artifact@v2
@@ -463,7 +463,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -490,7 +490,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -517,7 +517,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -544,7 +544,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -571,7 +571,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -598,7 +598,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -625,7 +625,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -652,7 +652,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -679,7 +679,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -706,7 +706,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -758,7 +758,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -786,7 +786,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -814,7 +814,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -842,7 +842,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -870,7 +870,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -898,7 +898,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -926,7 +926,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -954,7 +954,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -982,7 +982,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1010,7 +1010,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1062,7 +1062,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1090,7 +1090,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1118,7 +1118,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1146,7 +1146,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1174,7 +1174,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1202,7 +1202,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1230,7 +1230,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1258,7 +1258,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1286,7 +1286,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1314,7 +1314,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1367,7 +1367,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bh
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bh
         uses: actions/upload-artifact@v2
@@ -1396,7 +1396,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bisort
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bisort
         uses: actions/upload-artifact@v2
@@ -1425,7 +1425,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/em3d
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of em3d
         uses: actions/upload-artifact@v2
@@ -1454,7 +1454,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/health
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of health
         uses: actions/upload-artifact@v2
@@ -1483,7 +1483,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/mst
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of mst
         uses: actions/upload-artifact@v2
@@ -1512,7 +1512,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/perimeter
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of perimeter
         uses: actions/upload-artifact@v2
@@ -1541,7 +1541,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/power
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of power
         uses: actions/upload-artifact@v2
@@ -1570,7 +1570,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/treeadd
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of treeadd
         uses: actions/upload-artifact@v2
@@ -1599,7 +1599,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/tsp
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of tsp
         uses: actions/upload-artifact@v2
@@ -1628,7 +1628,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/voronoi
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of voronoi
         uses: actions/upload-artifact@v2
@@ -1690,7 +1690,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1716,7 +1716,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1742,7 +1742,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -1768,7 +1768,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -1794,7 +1794,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -1857,7 +1857,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -1884,7 +1884,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -1911,7 +1911,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -1938,7 +1938,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -1965,7 +1965,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2028,7 +2028,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2055,7 +2055,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2082,7 +2082,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2109,7 +2109,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2136,7 +2136,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2200,7 +2200,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of anagram
         uses: actions/upload-artifact@v2
@@ -2228,7 +2228,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of bc
         uses: actions/upload-artifact@v2
@@ -2256,7 +2256,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ft
         uses: actions/upload-artifact@v2
@@ -2284,7 +2284,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ks
         uses: actions/upload-artifact@v2
@@ -2312,7 +2312,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of yacr2
         uses: actions/upload-artifact@v2
@@ -2364,7 +2364,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2410,7 +2410,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2456,7 +2456,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2503,7 +2503,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibArchive
         uses: actions/upload-artifact@v2
@@ -2549,7 +2549,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2596,7 +2596,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2643,7 +2643,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2691,7 +2691,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Lua
         uses: actions/upload-artifact@v2
@@ -2743,7 +2743,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2795,7 +2795,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2847,7 +2847,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2900,7 +2900,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of LibTiff
         uses: actions/upload-artifact@v2
@@ -2945,7 +2945,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -2992,7 +2992,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3039,7 +3039,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3087,7 +3087,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of ZLib
         uses: actions/upload-artifact@v2
@@ -3130,7 +3130,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3173,7 +3173,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3216,7 +3216,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3260,7 +3260,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Icecast
         uses: actions/upload-artifact@v2
@@ -3303,7 +3303,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3347,7 +3347,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3391,7 +3391,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2
@@ -3436,7 +3436,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           mkdir 3c_performance_stats/
-          cp *.json 3c_performance_stats/
+          cp PerWildPtrStats.json TotalConstraintStats.json.aggregate.json TotalConstraintStats.json WildPtrStats.json 3c_performance_stats/
 
       - name: Upload 3c stats of Thttpd
         uses: actions/upload-artifact@v2

--- a/.github/workflows/exhaustivestats.yml
+++ b/.github/workflows/exhaustivestats.yml
@@ -19,6 +19,7 @@ env:
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
   clang_rename: "clang-rename-10"
+  actions_repo: "${{github.workspace}}/depsfolder/actions"
 
 jobs:
 
@@ -115,6 +116,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -154,6 +156,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -183,7 +186,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_no_alltypes:
     name: Test Vsftpd (macro-expanded, no -alltypes)
@@ -194,6 +197,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -234,6 +238,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -264,7 +269,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_no_alltypes:
     name: Test Parson (not macro-expanded, no -alltypes)
@@ -275,6 +280,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -314,6 +320,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -343,7 +350,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_no_alltypes:
     name: Test Parson (macro-expanded, no -alltypes)
@@ -354,6 +361,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -394,6 +402,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -424,7 +433,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Olden_no_expand_macros_no_alltypes:
     name: Test Olden (not macro-expanded, no -alltypes)
@@ -435,6 +444,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -728,6 +738,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -760,7 +771,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -788,7 +799,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -816,7 +827,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -844,7 +855,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -872,7 +883,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -900,7 +911,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -928,7 +939,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -956,7 +967,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -984,7 +995,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1012,7 +1023,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1031,6 +1042,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1334,6 +1346,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -1367,7 +1380,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -1396,7 +1409,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -1425,7 +1438,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -1454,7 +1467,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -1483,7 +1496,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -1512,7 +1525,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -1541,7 +1554,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -1570,7 +1583,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -1599,7 +1612,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1628,7 +1641,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1647,6 +1660,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1812,6 +1826,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1855,7 +1870,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1882,7 +1897,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1909,7 +1924,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -1936,7 +1951,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -1963,7 +1978,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1982,6 +1997,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2152,6 +2168,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -2196,7 +2213,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -2224,7 +2241,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -2252,7 +2269,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -2280,7 +2297,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -2308,7 +2325,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -2327,6 +2344,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2371,6 +2389,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2405,7 +2424,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_no_alltypes:
     name: Test LibArchive (macro-expanded, no -alltypes)
@@ -2416,6 +2435,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2461,6 +2481,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -2496,7 +2517,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_no_alltypes:
     name: Test Lua (not macro-expanded, no -alltypes)
@@ -2507,6 +2528,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2552,6 +2574,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2587,7 +2610,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_no_alltypes:
     name: Test Lua (macro-expanded, no -alltypes)
@@ -2598,6 +2621,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2644,6 +2668,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -2680,7 +2705,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_no_alltypes:
     name: Test LibTiff (not macro-expanded, no -alltypes)
@@ -2691,6 +2716,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2741,6 +2767,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2781,7 +2808,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_no_alltypes:
     name: Test LibTiff (macro-expanded, no -alltypes)
@@ -2792,6 +2819,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2843,6 +2871,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -2884,7 +2913,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_no_alltypes:
     name: Test ZLib (not macro-expanded, no -alltypes)
@@ -2895,6 +2924,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -2940,6 +2970,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -2975,7 +3006,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_no_alltypes:
     name: Test ZLib (macro-expanded, no -alltypes)
@@ -2986,6 +3017,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3032,6 +3064,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -3068,7 +3101,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_no_alltypes:
     name: Test Icecast (not macro-expanded, no -alltypes)
@@ -3079,6 +3112,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3120,6 +3154,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3151,7 +3186,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_no_alltypes:
     name: Test Icecast (macro-expanded, no -alltypes)
@@ -3162,6 +3197,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3204,6 +3240,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -3236,7 +3273,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_no_alltypes:
     name: Test Thttpd (not macro-expanded, no -alltypes)
@@ -3247,6 +3284,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3289,6 +3327,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3321,7 +3360,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_no_alltypes:
     name: Test Thttpd (macro-expanded, no -alltypes)
@@ -3332,6 +3371,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3375,6 +3415,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -3408,4 +3449,4 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ env:
   benchmark_conv_dir: "${{github.workspace}}/benchmark_conv"
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
+  clang_rename: "clang-rename-10"
 
 jobs:
 
@@ -1577,7 +1578,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -1609,7 +1610,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -1642,7 +1643,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -1675,7 +1676,7 @@ jobs:
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
           ( cd src ; \
-            clang-rename-10 -pl -i \
+            ${{env.clang_rename}} -pl -i \
               --qualified-name=main \
               --new-name=luac_main \
               luac.c )
@@ -1712,7 +1713,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -1749,7 +1750,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -1787,7 +1788,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)
@@ -1825,7 +1826,7 @@ jobs:
           bear ninja -l $(nproc) tiff
           ( cd tools ; \
             for i in *.c ; do \
-              clang-rename-10 -pl -i \
+              ${{env.clang_rename}} -pl -i \
                 --qualified-name=main \
                 --new-name=$(basename -s .c $i)_main $i ; \
             done)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ env:
   branch_for_scheduled_run: "main"
   port_tools: "${{github.workspace}}/depsfolder/checkedc-clang/clang/tools/3c/utils/port_tools"
   clang_rename: "clang-rename-10"
+  actions_repo: "${{github.workspace}}/depsfolder/actions"
 
 jobs:
 
@@ -118,6 +119,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -144,6 +146,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -160,7 +163,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_vsftpd_expand_macros_no_alltypes:
     name: Test Vsftpd (macro-expanded, no -alltypes)
@@ -171,6 +174,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -198,6 +202,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf vsftpd-3.0.3
           tar -xvzf ${{env.benchmark_tar_dir}}/vsftpd-3.0.3.tar.gz
           cd vsftpd-3.0.3
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion"
@@ -215,7 +220,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/vsftpd-3.0.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang -w -ferror-limit=0 -Wno-enum-conversion" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_no_expand_macros_no_alltypes:
     name: Test Parson (not macro-expanded, no -alltypes)
@@ -226,6 +231,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -252,6 +258,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -268,7 +275,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Parson_expand_macros_no_alltypes:
     name: Test Parson (macro-expanded, no -alltypes)
@@ -279,6 +286,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -306,6 +314,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf parson
           tar -xvzf ${{env.benchmark_tar_dir}}/parson.tar.gz
           cd parson
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang"
@@ -323,7 +332,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/parson
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_Olden_no_expand_macros_no_alltypes:
     name: Test Olden (not macro-expanded, no -alltypes)
@@ -334,6 +343,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -497,6 +507,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -516,7 +527,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -531,7 +542,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -546,7 +557,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -561,7 +572,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -576,7 +587,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -591,7 +602,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -606,7 +617,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -621,7 +632,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -636,7 +647,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -651,7 +662,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -670,6 +681,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -843,6 +855,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf Olden
           tar -xvzf ${{env.benchmark_tar_dir}}/Olden.tar.gz
           cd Olden
           for i in bh bisort em3d health mst perimeter power treeadd tsp voronoi ; do \
@@ -863,7 +876,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bh
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bh >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert bisort
         run: |
@@ -879,7 +892,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/bisort
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bisort >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert em3d
         run: |
@@ -895,7 +908,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/em3d
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo em3d >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert health
         run: |
@@ -911,7 +924,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/health
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo health >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert mst
         run: |
@@ -927,7 +940,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/mst
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo mst >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert perimeter
         run: |
@@ -943,7 +956,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/perimeter
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo perimeter >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert power
         run: |
@@ -959,7 +972,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/power
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo power >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert treeadd
         run: |
@@ -975,7 +988,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/treeadd
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo treeadd >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert tsp
         run: |
@@ -991,7 +1004,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/tsp
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo tsp >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Convert voronoi
         run: |
@@ -1007,7 +1020,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/voronoi
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo voronoi >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/Olden/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1026,6 +1039,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1126,6 +1140,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1156,7 +1171,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1170,7 +1185,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1184,7 +1199,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -1198,7 +1213,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -1212,7 +1227,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1231,6 +1246,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1336,6 +1352,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf ptrdist-1.1
           tar -xvzf ${{env.benchmark_tar_dir}}/ptrdist-1.1.tar.gz
           cd ptrdist-1.1
           ( cd yacr2
@@ -1367,7 +1384,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/anagram
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo anagram >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert bc
         run: |
@@ -1382,7 +1399,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/bc
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo bc >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ft
         run: |
@@ -1397,7 +1414,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ft
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ft >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert ks
         run: |
@@ -1412,7 +1429,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/ks
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo ks >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Convert yacr2
         run: |
@@ -1427,7 +1444,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/yacr2
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k LOCAL_CFLAGS="-w -ferror-limit=0 -D_ISOC99_SOURCE" 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py || echo yacr2 >>${{env.benchmark_conv_dir}}/expand_macros_alltypes/ptrdist-1.1/failed-components-list.txt
 
       - name: Check for deferred post-conversion build failures
         run: |
@@ -1446,6 +1463,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -1477,6 +1495,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -1498,7 +1517,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libarchive_expand_macros_no_alltypes:
     name: Test LibArchive (macro-expanded, no -alltypes)
@@ -1509,6 +1528,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -1541,6 +1561,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf libarchive-3.4.3
           tar -xvzf ${{env.benchmark_tar_dir}}/libarchive-3.4.3.tar.gz
           cd libarchive-3.4.3
           cd build
@@ -1563,7 +1584,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/libarchive-3.4.3
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 archive 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 archive 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_no_expand_macros_no_alltypes:
     name: Test Lua (not macro-expanded, no -alltypes)
@@ -1574,6 +1595,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -1606,6 +1628,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -1628,7 +1651,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_lua_expand_macros_no_alltypes:
     name: Test Lua (macro-expanded, no -alltypes)
@@ -1639,6 +1662,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -1672,6 +1696,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf lua-5.4.1
           tar -xvzf ${{env.benchmark_tar_dir}}/lua-5.4.1.tar.gz
           cd lua-5.4.1
           bear make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" CFLAGS="-w -ferror-limit=0" linux
@@ -1695,7 +1720,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/lua-5.4.1
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           sed -i "s/luac_main/main/" src/luac.c
-          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync CC="${{env.builddir}}/bin/clang" -k CFLAGS="-w -ferror-limit=0" linux 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_no_expand_macros_no_alltypes:
     name: Test LibTiff (not macro-expanded, no -alltypes)
@@ -1706,6 +1731,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -1743,6 +1769,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -1770,7 +1797,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_libtiff_expand_macros_no_alltypes:
     name: Test LibTiff (macro-expanded, no -alltypes)
@@ -1781,6 +1808,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -1819,6 +1847,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf tiff-4.1.0
           tar -xvzf ${{env.benchmark_tar_dir}}/tiff-4.1.0.tar.gz
           for i in ${{env.benchmark_tar_dir}}/tiff-4.1.0_patches/*; do patch -s -p0 < $i; done
           cd tiff-4.1.0
@@ -1847,7 +1876,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/tiff-4.1.0
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 tiff 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_no_expand_macros_no_alltypes:
     name: Test ZLib (not macro-expanded, no -alltypes)
@@ -1858,6 +1887,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -1890,6 +1920,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -1912,7 +1943,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_zlib_expand_macros_no_alltypes:
     name: Test ZLib (macro-expanded, no -alltypes)
@@ -1923,6 +1954,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -1956,6 +1988,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf zlib-1.2.11
           tar -xvzf ${{env.benchmark_tar_dir}}/zlib-1.2.11.tar.gz
           cd zlib-1.2.11
           mkdir build
@@ -1979,7 +2012,7 @@ jobs:
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/zlib-1.2.11
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
           cd build
-          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          ninja -l $(nproc) -k 0 zlib 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_no_expand_macros_no_alltypes:
     name: Test Icecast (not macro-expanded, no -alltypes)
@@ -1990,6 +2023,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -2018,6 +2052,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -2036,7 +2071,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_icecast_expand_macros_no_alltypes:
     name: Test Icecast (macro-expanded, no -alltypes)
@@ -2047,6 +2082,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -2076,6 +2112,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf icecast-2.4.4
           tar -xvzf ${{env.benchmark_tar_dir}}/icecast-2.4.4.tar.gz
           cd icecast-2.4.4
           sed -i '/_GNU_SOURCE/d' configure
@@ -2095,7 +2132,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/icecast-2.4.4
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make -j $(nproc) -l $(nproc) --output-sync -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_no_expand_macros_no_alltypes:
     name: Test Thttpd (not macro-expanded, no -alltypes)
@@ -2106,6 +2143,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_no_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -2135,6 +2173,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -2154,7 +2193,7 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/no_expand_macros_alltypes/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py
 
   test_thttpd_expand_macros_no_alltypes:
     name: Test Thttpd (macro-expanded, no -alltypes)
@@ -2165,6 +2204,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_no_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -2195,6 +2235,7 @@ jobs:
         run: |
           mkdir -p ${{env.benchmark_conv_dir}}/expand_macros_alltypes
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes
+          rm -rf thttpd-2.29
           tar -xvzf ${{env.benchmark_tar_dir}}/thttpd-2.29.tar.gz
           for i in ${{env.benchmark_tar_dir}}/thttpd-2.29_patches/*; do patch -s -p0 < $i; done
           cd thttpd-2.29
@@ -2215,4 +2256,4 @@ jobs:
         run: |
           cd ${{env.benchmark_conv_dir}}/expand_macros_alltypes/thttpd-2.29
           if [ -e "out.checked" ]; then cp -r out.checked/* . && rm -r out.checked; fi
-          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{github.workspace}}/depsfolder/actions/filter-bounds-inference-errors.py
+          make CC="${{env.builddir}}/bin/clang -w -ferror-limit=0" -k 2>&1 | ${{env.actions_repo}}/filter-bounds-inference-errors.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.mypy_cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /.mypy_cache
-/*-local.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.mypy_cache
+/*-local.sh

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -106,6 +106,11 @@ cmake_checkedc = 'cmake -DCMAKE_C_COMPILER=${{env.builddir}}/bin/clang'
 # benchmarks that we don't factor out anything more here.
 common_cflags = '-w -ferror-limit=0'
 
+stats_filenames = [
+    'PerWildPtrStats.json', 'TotalConstraintStats.json.aggregate.json',
+    'TotalConstraintStats.json', 'WildPtrStats.json'
+]
+
 # There is a known incompatibility between the vsftpd version we're using and
 # Clang: vsftpd triggers a -Wenum-conversion warning that becomes an error with
 # -Werror. See, for example:
@@ -685,7 +690,7 @@ def generate_benchmark_job(out: TextIO, binfo: BenchmarkInfo,
                             cd {component_dir}
                             mkdir -p {all_stats_dir}
                             rm -f {stats_zip}
-                            zip {stats_zip} *.json
+                            zip {stats_zip} {' '.join(stats_filenames)}
                         ''')))
             else:
                 perf_dir_name = "3c_performance_stats/"
@@ -695,7 +700,7 @@ def generate_benchmark_job(out: TextIO, binfo: BenchmarkInfo,
                         textwrap.dedent(f'''\
                             cd {component_dir}
                             mkdir {perf_dir_name}
-                            cp *.json {perf_dir_name}
+                            cp {' '.join(stats_filenames)} {perf_dir_name}
                         ''')))
                 perf_dir = os.path.join(component_dir, perf_dir_name)
                 steps.append(

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -935,6 +935,11 @@ def generate_local_script(config: WorkflowConfig) -> None:
 # edited by a user for customization.
 #
 # Workflow configuration name: {config.filename}
+
+# TODO: Make this per-job so if one job fails, the others still run (as in the
+# GitHub workflow)?
+set -e
+trap 'echo >&2 "*** Exiting workflow early due to failed command. ***"' ERR
 ''')
     generate_benchmark_jobs(tmp_out, config, True)
     script = tmp_out.getvalue()

--- a/generate-workflow.py
+++ b/generate-workflow.py
@@ -136,8 +136,10 @@ thttpd_make = f'make CC="${{{{env.builddir}}}}/bin/clang {common_cflags}"'
 ptrdist_components = ['anagram', 'bc', 'ft', 'ks', 'yacr2']
 ptrdist_manual_components = ['anagram', 'ft', 'ks', 'yacr2']
 
-olden_components = ['bh', 'bisort', 'em3d', 'health', 'mst',
-                    'perimeter', 'power', 'treeadd', 'tsp', 'voronoi']
+olden_components = [
+    'bh', 'bisort', 'em3d', 'health', 'mst', 'perimeter', 'power', 'treeadd',
+    'tsp', 'voronoi'
+]
 
 # The blank comments below stop YAPF from reformatting things in ways we don't
 # want; large data literals are a known weakness of YAPF
@@ -597,7 +599,9 @@ def generate_benchmark_job(out: TextIO,
     ''') + apply_patch_cmd + change_dir + ensure_trailing_newline(
         binfo.build_cmds)
 
-    steps: List[Step] = [RunStep('Build ' + binfo.friendly_name, full_build_cmds)]
+    steps: List[Step] = [
+        RunStep('Build ' + binfo.friendly_name, full_build_cmds)
+    ]
 
     components = binfo.components
     if components is None:
@@ -707,17 +711,15 @@ workflow_file_configs = [
                    variants=[Variant(alltypes=False),
                              Variant(alltypes=True)],
                    cron_timestamp="0 5 * * *"),
-    WorkflowConfig(
-        filename="exhaustivestats",
-        friendly_name="Exhaustive testing and Performance Stats",
-        variants=[
-            Variant(alltypes=False),
-            Variant(alltypes=True)
-        ],
-        generate_stats=True),
+    WorkflowConfig(filename="exhaustivestats",
+                   friendly_name="Exhaustive testing and Performance Stats",
+                   variants=[Variant(alltypes=False),
+                             Variant(alltypes=True)],
+                   generate_stats=True),
     WorkflowConfig(
         filename="exhaustiveleastgreatest",
-        friendly_name="Exhaustive testing and Performance Stats (Least and Greatest)",
+        friendly_name=
+        "Exhaustive testing and Performance Stats (Least and Greatest)",
         variants=[
             Variant(alltypes=True,
                     extra_3c_args=['-only-g-sol'],

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+[mypy]
+disallow_untyped_defs = true
+
+# To enable narrower suppression comments.
+show_error_codes = true
+
+# The current version of dmypy in our preferred Ubuntu 20.04 environment (0.761)
+# doesn't support `follow_imports = normal`; that was added in 0.780
+# (https://github.com/python/mypy/issues/5870). `follow_imports = error` is
+# working for me in VSCodium so far. ~ Matt 2022-01-06
+follow_imports = error

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,9 @@
 [mypy]
 disallow_untyped_defs = true
+# TODO: I'd like to disallow variables that have an implicit Any type (e.g.,
+# variables copied from fields of an argparse args object), but I don't see an
+# option for that as of 2022-01-07. disallow_any_expr causes so many other
+# errors that it isn't worth it. ~ Matt
 
 # To enable narrower suppression comments.
 show_error_codes = true


### PR DESCRIPTION
Work in progress, to be used as part of the `oopsla2022-artifact` branch (which may have additional, unrelated changes for the artifact) and later polished up and merged to `main`.  In the meantime, anyone who wants can still manually check out the `run-locally` branch to run benchmarks locally if they are OK with the current limitations.

Example usage:
```
./generate-workflow.py local --output local.sh \
  --workflow-config main --benchmark zlib --subvariant no_expand_macros_no_alltypes \
  --3c-source-dir ~/3c --3c-build-dir ~/3c/build \
  --checkedc-benchmarks-dir ~/checkedc-benchmarks \
  --work-dir ~/benchmarks/gwl-work
./local.sh
```

TODO:
- [x] Stats generation: zips are saved to a `stats` directory in the same format as GitHub artifacts
- [ ] Error handling: `--skip-post-conversion-build` is available as a stopgap